### PR TITLE
Add more strictness when decoding

### DIFF
--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 module Data.Binary.Serialise.CBOR.Class (
     -- * The Serialise class
@@ -11,6 +12,7 @@ import Data.Binary.Serialise.CBOR.Decoding
 
 import Data.Monoid
 import Control.Applicative
+import Control.DeepSeq
 
 import Data.Word
 import Data.Int
@@ -148,7 +150,9 @@ instance (Serialise a, Serialise b) => Serialise (a,b) where
                 <> encode a
                 <> encode b
     decode = do decodeListLenOf 2
-                (,) <$> decode <*> decode
+                !x <- decode
+                !y <- decode
+                return $! (x, y)
 
 instance (Serialise a, Serialise b, Serialise c) => Serialise (a,b,c) where
     encode (a,b,c) = encodeListLen 3
@@ -157,7 +161,10 @@ instance (Serialise a, Serialise b, Serialise c) => Serialise (a,b,c) where
                   <> encode c
 
     decode = do decodeListLenOf 3
-                (,,) <$> decode <*> decode <*> decode
+                !x <- decode
+                !y <- decode
+                !z <- decode
+                return $! (x, y, z)
 
 instance Serialise a => Serialise (Maybe a) where
     encode Nothing  = encodeListLen 0
@@ -165,8 +172,9 @@ instance Serialise a => Serialise (Maybe a) where
 
     decode = do n <- decodeListLen
                 case n of
-                  0 -> pure Nothing
-                  1 -> Just <$> decode
+                  0 -> return $! Nothing
+                  1 -> do !x <- decode
+                          return $! Just x
                   _ -> fail "unknown tag"
 
 instance (Serialise a, Serialise b) => Serialise (Either a b) where
@@ -176,8 +184,10 @@ instance (Serialise a, Serialise b) => Serialise (Either a b) where
     decode = do decodeListLenOf 2
                 t <- decodeWord
                 case t of
-                  0 -> Left  <$> decode
-                  1 -> Right <$> decode
+                  0 -> do !x <- decode
+                          return $! x
+                  1 -> do !x <- decode
+                          return $! x
                   _ -> fail "unknown tag"
 
 ------------------------
@@ -188,11 +198,13 @@ instance Serialise Version where
     encode (Version ns ts) = encodeListLen 3
                           <> encodeWord 0 <> encode ns <> encode ts
     decode = do
-      len <- decodeListLen
-      tag <- decodeWord
+      !len <- decodeListLen
+      !tag <- decodeWord
       case tag of
         0 | len == 3
-          -> Version <$> decode <*> decode
+          -> do !x <- decode
+                !y <- decode
+                return $! Version x y
         _ -> fail "unexpected tag"
 
 ------------------------
@@ -205,11 +217,11 @@ instance Serialise UTCTime where
             <> encode (formatUTCrfc3339 d)
 
     decode = do
-      tag <- decodeTag
+      !tag <- decodeTag
       case tag of
-        0 -> do str <- decodeString
+        0 -> do !str <- decodeString
                 case parseUTCrfc3339 (Text.unpack str) of
-                  Just t  -> return t
+                  Just t  -> return $! force t
                   Nothing -> fail "Could not parse RFC3339 date"
         _ -> fail "Expected timestamp (tag 0 or 1)"
 

--- a/Data/Binary/Serialise/CBOR/Decoding.hs
+++ b/Data/Binary/Serialise/CBOR/Decoding.hs
@@ -371,7 +371,7 @@ decodeSequenceLenIndef f z g get =
     go !acc = do
       stop <- decodeBreakOr
       if stop then return $! g acc
-              else do x <- get; go (f acc x)
+              else do !x <- get; go (f acc x)
 
 {-# INLINE decodeSequenceLenN #-}
 decodeSequenceLenN :: (r -> a -> r)
@@ -384,5 +384,5 @@ decodeSequenceLenN f z g c get =
     go z c
   where
     go !acc 0 = return $! g acc
-    go !acc n = do x <- get; go (f acc x) (n-1)
+    go !acc n = do !x <- get; go (f acc x) (n-1)
 

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -37,6 +37,7 @@ library
                      bytestring >= 0.10.4 && <0.11,
                      array,
                      binary,
+                     deepseq,
                      time
   if flag(newtime15)
     build-depends:   time >= 1.5


### PR DESCRIPTION
This avoids thunks accumulating during decoding, on the assumption that we ultimately want the decoded result to be fully evaluated. It's possible that not all the strictness annotations are necessary.
Special treatment is needed for `UTCTime`, because `parseTimeM` isn't sufficiently strict.