### PR TITLE
More cleanups

### DIFF
--- a/Data/Binary/Serialise/CBOR.hs
+++ b/Data/Binary/Serialise/CBOR.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
 -- |
--- Module      : Data.Binary.Serialise.CBOR.ByteOrder
+-- Module      : Data.Binary.Serialise.CBOR
 -- Copyright   : (c) Duncan Coutts 2015
 -- License     : BSD3-style (see LICENSE.txt)
 --
@@ -10,49 +10,51 @@
 -- Portability : non-portable (GHC extensions)
 --
 -- This module provides functions to serialise and deserialise Haskell
--- values for storage or transmission. It also provides a type class
+-- values for storage or transmission, to and from lazy
+-- @'Data.ByteString.Lazy.ByteString'@s. It also provides a type class
 -- and utilities to help you make your types serialisable.
 --
-module Data.Binary.Serialise.CBOR (
-    -- * Serialization and derialization of Haskell values
-
-    -- ** Convenience functions
+-- For a full tutorial on using this module, see
+-- "Data.Binary.Serialise.CBOR.Tutorial".
+--
+module Data.Binary.Serialise.CBOR
+  ( -- * High level API
+    -- $highlevel
     serialise,
     deserialise,
     deserialiseOrFail,
+
+    -- TODO FIXME: move to IO module?
     writeFileSerialise,
     readFileDeserialise,
     hPutSerialise,
+    DeserialiseFailure(..),
 
-    -- ** The primitives
+    -- * Primitive, incremental interface
+    -- $primitives
     serialiseIncremental,
     deserialiseIncremental,
 
-    -- * Making types serializable
-    -- ** The Serialise class
-    -- | 
+    -- * The @'Serialise'@ class
     Serialise(..),
   ) where
 
---import Data.Serialise.Serialise.CBOR.Encode
---import Data.Serialise.Serialise.CBOR.Decode
+import qualified Data.Binary.Get                  as Bin
 import           Data.Binary.Serialise.CBOR.Class
 import qualified Data.Binary.Serialise.CBOR.Read  as CBOR.Read
 import qualified Data.Binary.Serialise.CBOR.Write as CBOR.Write
-import qualified Data.Binary.Get as Bin
+
+import qualified Data.ByteString.Builder          as BS
+import qualified Data.ByteString.Lazy             as BS
+import qualified Data.ByteString.Lazy.Internal    as BS
+
+import           Control.Exception
+import           Data.Typeable
+import           System.IO
 
 
-import qualified Data.ByteString.Lazy as BS
-import qualified Data.ByteString.Lazy.Internal as BS
-import qualified Data.ByteString.Builder as BS
-
-import System.IO
-import Data.Typeable
-import Control.Exception
-
-
--------------------
--- The primitives
+-- $primitives
+-- The following API...
 --
 
 -- | Serialise a Haskell value to an external binary representation.
@@ -76,8 +78,8 @@ serialiseIncremental = CBOR.Write.toBuilder . encode
 deserialiseIncremental :: Serialise a => Bin.Decoder a
 deserialiseIncremental = CBOR.Read.deserialiseIncremental decode
 
---------------------------
--- Convenience functions
+-- $highlevel
+-- This is a test
 --
 
 -- | Serialise a Haskell value to an external binary representation.

--- a/Data/Binary/Serialise/CBOR.hs
+++ b/Data/Binary/Serialise/CBOR.hs
@@ -107,12 +107,16 @@ deserialise =
       error $ "Data.Binary.Serialise.CBOR.deserialise: failed at offset "
            ++ show off ++ " : " ++ msg
 
+-- | An exception type that may be returned (by pure functions) or
+-- thrown (by IO actions) that fail to deserialise a given input.
 data DeserialiseFailure =
        DeserialiseFailure Bin.ByteOffset String
   deriving (Show, Typeable)
 
 instance Exception DeserialiseFailure
 
+-- | Strictly deserialise an entire @'BS.ByteString'@ and get back a
+-- resulting value of the specified type, or a @'DeserialiseFailure'@
 deserialiseOrFail :: Serialise a => BS.ByteString -> Either DeserialiseFailure a
 deserialiseOrFail = supplyAllInput deserialiseIncremental
   where

--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -11,7 +11,7 @@
 -- Portability : non-portable (GHC extensions)
 --
 -- The @'Serialise'@ class allows you to encode a given type into a
--- CBOR object.
+-- CBOR object, or decode a CBOR object into the user-specified type.
 --
 module Data.Binary.Serialise.CBOR.Class
   ( -- * The Serialise class

--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP          #-}
 
 -- |
 -- Module      : Data.Binary.Serialise.CBOR.Class
@@ -10,63 +10,74 @@
 -- Stability   : experimental
 -- Portability : non-portable (GHC extensions)
 --
--- Lorem ipsum...
+-- The @'Serialise'@ class allows you to encode a given type into a
+-- CBOR object.
 --
-module Data.Binary.Serialise.CBOR.Class (
-    -- * The Serialise class
-    Serialise(..),
-    -- ** Instance helpers
-    encodeShortList
+module Data.Binary.Serialise.CBOR.Class
+  ( -- * The Serialise class
+    Serialise(..)
   ) where
 
-import Data.Binary.Serialise.CBOR.Encoding
-import Data.Binary.Serialise.CBOR.Decoding
+import           Data.Int
+import           Data.Monoid
+import           Data.Version
+import           Data.Word
 
-import Data.Monoid
+import qualified Data.ByteString                     as BS
+import qualified Data.Text                           as Text
 
-import Data.Word
-import Data.Int
-import qualified Data.Text       as Text
-import qualified Data.ByteString as BS
-import Data.Version
+-- TODO: more instances
+--import qualified Data.Array                          as Array
+--import qualified Data.Array.Unboxed                  as UArray
+--import qualified Data.ByteString                     as BS.Lazy
+--import qualified Data.Map                            as Map
+--import qualified Data.Sequence                       as Sequence
+--import qualified Data.Set                            as Set
+--import qualified Data.Text.Lazy                      as Text.Lazy
 
---TODO: lots more instances
---import qualified Data.Text.Lazy  as Text.Lazy
---import qualified Data.ByteString as BS.Lazy
---import qualified Data.Map  as Map
---import qualified Data.Set  as Set
---import qualified Data.Sequence as Sequence
---import qualified Data.Array as Array
---import qualified Data.Array.Unboxed as UArray
-
-import Data.Time (UTCTime(..))
+import           Data.Time                           (UTCTime (..))
 #if MIN_VERSION_time(1,5,0)
-import Data.Time.Format (formatTime, parseTimeM, defaultTimeLocale)
+import           Data.Time.Format                    (defaultTimeLocale,
+                                                      formatTime, parseTimeM)
 #else
-import Data.Time.Format (formatTime, parseTime)
-import System.Locale    (defaultTimeLocale)
+import           Data.Time.Format                    (formatTime, parseTime)
+import           System.Locale                       (defaultTimeLocale)
 #endif
 
-import Prelude hiding (encodeFloat, decodeFloat)
+import           Prelude                             hiding (decodeFloat,
+                                                      encodeFloat)
 
-------------------------
+import           Data.Binary.Serialise.CBOR.Decoding
+import           Data.Binary.Serialise.CBOR.Encoding
+
+--------------------------------------------------------------------------------
 -- The Serialise class
---
 
+-- | Types that are instances of the @'Serialise'@ class allow values
+-- to be quickly encoded or decoded directly to a CBOR representation,
+-- for object transmission or storage.
 class Serialise a where
+    {-# MINIMAL encode, decode #-}
+
+    -- | Definition for encoding a given type into a binary
+    -- representation, using the @'Encoding'@ @'Monoid'@.
     encode  :: a -> Encoding
+
+    -- | Definition of a given @'Decoder'@ for a type.
     decode  :: Decoder a
 
-    -- Mainly here to support the Char/String instance.
+    -- | Utility to support specialised encoding for some list type -
+    -- used for @'Char'@/@'String'@ instances in this package.
     encodeList :: [a] -> Encoding
     encodeList = defaultEncodeList
 
+    -- | Utility to support specialised decoding for some list type -
+    -- used for @'Char'@/@'String'@ instances in this package.
     decodeList :: Decoder [a]
     decodeList = defaultDecodeList
 
-------------------------
+--------------------------------------------------------------------------------
 -- Special list business
---
 
 instance Serialise a => Serialise [a] where
     encode = encodeList
@@ -85,14 +96,8 @@ defaultDecodeList = do
       Just n  -> decodeSequenceLenN     (flip (:)) [] reverse n decode
 
 
-encodeShortList :: Serialise a => [a] -> Encoding
-encodeShortList xs = encodeListLen (fromIntegral $ length xs)
-                  <> foldr (\x r -> encode x <> r) mempty xs
-
-
-------------------------
+--------------------------------------------------------------------------------
 -- Primitive instances
---
 
 instance Serialise () where
     encode = const encodeNull
@@ -151,9 +156,8 @@ instance Serialise BS.ByteString where
     decode = decodeBytes
 
 
-------------------------
+--------------------------------------------------------------------------------
 -- Structure instances
---
 
 instance (Serialise a, Serialise b) => Serialise (a,b) where
     encode (a,b) = encodeListLen 2
@@ -200,9 +204,8 @@ instance (Serialise a, Serialise b) => Serialise (Either a b) where
                           return x
                   _ -> fail "unknown tag"
 
-------------------------
+--------------------------------------------------------------------------------
 -- Misc base package instances
---
 
 instance Serialise Version where
     encode (Version ns ts) = encodeListLen 3
@@ -217,7 +220,7 @@ instance Serialise Version where
                 return (Version x y)
         _ -> fail "unexpected tag"
 
-------------------------
+--------------------------------------------------------------------------------
 -- Time instances
 --
 -- CBOR has some special encodings for times/timestamps

--- a/Data/Binary/Serialise/CBOR/Encoding.hs
+++ b/Data/Binary/Serialise/CBOR/Encoding.hs
@@ -13,33 +13,33 @@
 --
 module Data.Binary.Serialise.CBOR.Encoding
   ( -- * Encoding implementation
-    Encoding(..)
-  , Tokens(..)
+    Encoding(..)             -- :: *
+  , Tokens(..)               -- :: *
 
     -- * @'Encoder'@ API for serialisation
-  , encodeWord
-  , encodeWord64
-  , encodeInt
-  , encodeInt64
-  , encodeInteger
-  , encodeBytes
-  , encodeBytesIndef
-  , encodeString
-  , encodeStringIndef
-  , encodeListLen
-  , encodeListLenIndef
-  , encodeMapLen
-  , encodeMapLenIndef
-  , encodeBreak
-  , encodeTag
-  , encodeTag64
-  , encodeBool
-  , encodeUndef
-  , encodeNull
-  , encodeSimple
-  , encodeFloat16
-  , encodeFloat
-  , encodeDouble
+  , encodeWord               -- :: Word -> Encoding
+  , encodeWord64             -- :: Word64 -> Encoding
+  , encodeInt                -- :: Int -> Encoding
+  , encodeInt64              -- :: Int64 -> Encoding
+  , encodeInteger            -- :: Integer -> Encoding
+  , encodeBytes              -- :: B.ByteString -> Encoding
+  , encodeBytesIndef         -- :: Encoding
+  , encodeString             -- :: T.Text -> Encoding
+  , encodeStringIndef        -- :: Encoding
+  , encodeListLen            -- :: Word -> Encoding
+  , encodeListLenIndef       -- :: Encoding
+  , encodeMapLen             -- :: Word -> Encoding
+  , encodeMapLenIndef        -- :: Encoding
+  , encodeBreak              -- :: Encoding
+  , encodeTag                -- :: Word -> Encoding
+  , encodeTag64              -- :: Word64 -> Encoding
+  , encodeBool               -- :: Bool -> Encoding
+  , encodeUndef              -- :: Encoding
+  , encodeNull               -- :: Encoding
+  , encodeSimple             -- :: Word8 -> Encoding
+  , encodeFloat16            -- :: Float -> Encoding
+  , encodeFloat              -- :: Float -> Encoding
+  , encodeDouble             -- :: Double -> Encoding
   ) where
 
 import           Data.Int

--- a/Data/Binary/Serialise/CBOR/Encoding.hs
+++ b/Data/Binary/Serialise/CBOR/Encoding.hs
@@ -11,27 +11,59 @@
 --
 -- Lorem ipsum...
 --
-module Data.Binary.Serialise.CBOR.Encoding where
+module Data.Binary.Serialise.CBOR.Encoding
+  ( -- * Encoding implementation
+    Encoding(..)
+  , Tokens(..)
 
-import Data.Word
-import Data.Int
-import qualified Data.Text as T
-import qualified Data.ByteString as B
+    -- * @'Encoder'@ API for serialisation
+  , encodeWord
+  , encodeWord64
+  , encodeInt
+  , encodeInt64
+  , encodeInteger
+  , encodeBytes
+  , encodeBytesIndef
+  , encodeString
+  , encodeStringIndef
+  , encodeListLen
+  , encodeListLenIndef
+  , encodeMapLen
+  , encodeMapLenIndef
+  , encodeBreak
+  , encodeTag
+  , encodeTag64
+  , encodeBool
+  , encodeUndef
+  , encodeNull
+  , encodeSimple
+  , encodeFloat16
+  , encodeFloat
+  , encodeDouble
+  ) where
+
+import           Data.Int
+import           Data.Word
 #if __GLASGOW_HASKELL__ < 710
-import Data.Monoid
+import           Data.Monoid
 #endif
 
--- | An intermediate form used during serialisation. It supports efficient
--- concatenation.
+import qualified Data.ByteString as B
+import qualified Data.Text       as T
+
+import           Prelude         hiding (encodeFloat)
+
+-- | An intermediate form used during serialisation, specified as a
+-- @'Monoid'@. It supports efficient concatenation, and is equivalent
+-- to a specialised @'Data.Monoid.Endo' 'Tokens'@ type.
 --
--- It is used for the stage in serialisation where we flatten out the Haskell
--- data structure but it is independent of any specific external binary or text
--- format.
+-- It is used for the stage in serialisation where we flatten out the
+-- Haskell data structure but it is independent of any specific
+-- external binary or text format.
 --
 newtype Encoding = Encoding (Tokens -> Tokens)
 
 -- | A flattened representation of a term
---
 data Tokens =
 
     -- Positive and negative integers (type 0,1)
@@ -71,12 +103,14 @@ data Tokens =
     | TkEnd
 
 instance Monoid Encoding where
-  {-# INLINE mempty #-}
   mempty = Encoding (\ts -> ts)
-  {-# INLINE mappend #-}
+  {-# INLINE mempty #-}
+
   Encoding b1 `mappend` Encoding b2 = Encoding (\ts -> b1 (b2 ts))
-  {-# INLINE mconcat #-}
+  {-# INLINE mappend #-}
+
   mconcat = foldr mappend mempty
+  {-# INLINE mconcat #-}
 
 encodeWord :: Word -> Encoding
 encodeWord = Encoding . TkWord
@@ -117,7 +151,7 @@ encodeMapLen = Encoding . TkMapLen
 encodeMapLenIndef :: Encoding
 encodeMapLenIndef = Encoding TkMapBegin
 
-encodeBreak :: Encoding 
+encodeBreak :: Encoding
 encodeBreak = Encoding TkBreak
 
 encodeTag :: Word -> Encoding
@@ -146,4 +180,3 @@ encodeFloat = Encoding . TkFloat32
 
 encodeDouble :: Double -> Encoding
 encodeDouble = Encoding . TkFloat64
-

--- a/Data/Binary/Serialise/CBOR/IO.hs
+++ b/Data/Binary/Serialise/CBOR/IO.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+-- |
+-- Module      : Data.Binary.Serialise.CBOR.IO
+-- Copyright   : (c) Duncan Coutts 2015
+-- License     : BSD3-style (see LICENSE.txt)
+--
+-- Maintainer  : duncan@community.haskell.org
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+-- High-level file-based API for serialising and deserialising values.
+--
+module Data.Binary.Serialise.CBOR.IO
+  ( -- * High level file API
+    writeFileSerialise,
+    readFileDeserialise,
+
+    -- * High level @'Handle'@ API
+    hPutSerialise
+  ) where
+
+import           Control.Exception          (throwIO)
+import           System.IO                  (Handle, IOMode (..), withFile)
+
+import qualified Data.ByteString.Lazy       as BS
+
+import           Data.Binary.Serialise.CBOR
+
+--------------------------------------------------------------------------------
+
+-- | Serialise a @'BS.ByteString'@ (via @'serialise'@) and write it directly
+-- to the specified @'Handle'@.
+hPutSerialise :: Serialise a => Handle -> a -> IO ()
+hPutSerialise hnd x = BS.hPut hnd (serialise x)
+
+-- | Serialise a @'BS.ByteString'@ and write it directly to the
+-- specified file.
+writeFileSerialise :: Serialise a => FilePath -> a -> IO ()
+writeFileSerialise fname x =
+    withFile fname WriteMode $ \hnd -> hPutSerialise hnd x
+
+-- | Read the specified file (internally, by reading a @'BS.ByteString'@)
+-- and attempt to decode it into a Haskell value using @'deserialise'@
+-- (the type of which is determined by the choice of the result type).
+readFileDeserialise :: Serialise a => FilePath -> IO a
+readFileDeserialise fname =
+    withFile fname ReadMode $ \hnd -> do
+      input <- BS.hGetContents hnd
+      case deserialiseOrFail input of
+        Left  err -> throwIO err
+        Right x   -> return x

--- a/Data/Binary/Serialise/CBOR/IO.hs
+++ b/Data/Binary/Serialise/CBOR/IO.hs
@@ -43,6 +43,9 @@ writeFileSerialise fname x =
 -- | Read the specified file (internally, by reading a @'BS.ByteString'@)
 -- and attempt to decode it into a Haskell value using @'deserialise'@
 -- (the type of which is determined by the choice of the result type).
+--
+-- /Throws/: @'DeserialiseError@' iff the file fails to
+-- deserialise properly.
 readFileDeserialise :: Serialise a => FilePath -> IO a
 readFileDeserialise fname =
     withFile fname ReadMode $ \hnd -> do

--- a/Data/Binary/Serialise/CBOR/Write.hs
+++ b/Data/Binary/Serialise/CBOR/Write.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE UnboxedTuples       #-}
 
 -- |
 -- Module      : Data.Binary.Serialise.CBOR.Term
@@ -16,31 +16,29 @@
 --
 -- CBOR format support.
 --
-module Data.Binary.Serialise.CBOR.Write (
-
-    -- * Streams of values to be encoded
-    toBuilder,
-    toLazyByteString,
+module Data.Binary.Serialise.CBOR.Write
+  ( toBuilder         -- :: Encoding -> B.Builder
+  , toLazyByteString  -- :: Encoding -> L.ByteString
   ) where
 
-
-import Data.Binary.Serialise.CBOR.Encoding
-import Data.Binary.Serialise.CBOR.ByteOrder
-
-import           Data.Monoid
 import           Data.Bits
-import qualified Data.ByteString                                as S
-import qualified Data.ByteString.Builder                        as B
-import qualified Data.ByteString.Lazy                           as L
-import qualified Data.ByteString.Builder.Internal               as BI
-import qualified Data.ByteString.Builder.Prim.Internal         as PI
-import qualified Data.ByteString.Builder.Prim                  as P
-import           Data.ByteString.Builder.Prim  ( (>$<), (>*<), condB )
-import qualified Data.Text          as T
-import qualified Data.Text.Encoding as T
-import           Data.Word
 import           Data.Int
+import           Data.Monoid
+import           Data.Word
 import           Foreign.Ptr
+
+import qualified Data.ByteString                       as S
+import qualified Data.ByteString.Builder               as B
+import qualified Data.ByteString.Builder.Internal      as BI
+import           Data.ByteString.Builder.Prim          (condB, (>$<), (>*<))
+import qualified Data.ByteString.Builder.Prim          as P
+import qualified Data.ByteString.Builder.Prim.Internal as PI
+import qualified Data.ByteString.Lazy                  as L
+import qualified Data.Text                             as T
+import qualified Data.Text.Encoding                    as T
+
+import           Data.Binary.Serialise.CBOR.ByteOrder
+import           Data.Binary.Serialise.CBOR.Encoding
 
 #include "MachDeps.h"
 
@@ -51,14 +49,14 @@ import           Foreign.Ptr
 #error expected WORD_SIZE_IN_BITS to be 32 or 64
 #endif
 
-
 ------------------------------------------------------------------------
 
+-- | Turn an @'Encoding'@ into a @'L.ByteString'@ in MsgPack binary format.
 toLazyByteString :: Encoding -> L.ByteString
 toLazyByteString = B.toLazyByteString . toBuilder
 
--- | Turn an 'Encoding' into a bytestring 'B.Builder' in MsgPack binary format.
---
+-- | Turn an @'Encoding'@ into a @'L.ByteString'@ @'B.Builder'@ in MsgPack
+-- binary format.
 toBuilder :: Encoding -> B.Builder
 toBuilder =
     \(Encoding vs0) -> BI.builder (step (vs0 TkEnd))
@@ -89,7 +87,7 @@ toBuilder =
               TkTag      x vs' -> PI.runB tagMP      x op >>= go vs'
               TkTag64    x vs' -> PI.runB tag64MP      x op >>= go vs'
               TkInteger  x vs'
-                --TODO: for GMP can optimimise this by looking at the S# 
+                --TODO: for GMP can optimimise this by looking at the S#
                 -- constructors to see if it fits in an Int, and if it's
                 -- positive or negative.
                 | x >= 0
@@ -273,7 +271,7 @@ int64MP =
     prep n = (mt, ui)
       where
         sign :: Word64   -- extend sign to whole length
-        sign = fromIntegral (n `unsafeShiftR` intBits)        
+        sign = fromIntegral (n `unsafeShiftR` intBits)
 #if MIN_VERSION_base(4,7,0)
         intBits = finiteBitSize (undefined :: Int64) - 1
 #else
@@ -303,7 +301,7 @@ int64MP =
       two-byte length) followed by the two bytes 0x01f4 for a length of
       500, followed by 500 bytes of binary content.
 -}
-    
+
 bytesMP :: S.ByteString -> B.Builder
 bytesMP bs =
     P.primBounded bytesLenMP (fromIntegral $ S.length bs) <> B.byteString bs
@@ -471,7 +469,7 @@ integerMP n
 -}
 
 simpleMP :: P.BoundedPrim Word8
-simpleMP = 
+simpleMP =
     condB (<= 0x17) ((0xe0 +) >$< header) $
                     (withConstHeader 0xf8 P.word8)
 

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -1,6 +1,6 @@
 name:                binary-serialise-cbor
 version:             0.1.1.0
-synopsis:            Binary serialisation using the CBOR format
+synopsis:            Yet Another Binary Serialisation Library
 license:             BSD3
 license-files:       LICENSE.txt
 author:              Duncan Coutts
@@ -10,16 +10,19 @@ copyright:           2015 Duncan Coutts,
                      2015 IRIS Connect Ltd
 category:            Codec
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       >= 1.10
 
 description:
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-  eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-  ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-  aliquip ex ea commodo consequat. Duis aute irure dolor in
-  reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-  pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-  culpa qui officia deserunt mollit anim id est laborum.
+  This package provides pure, efficient serialization of Haskell
+  values directly into @ByteString@s for storage or transmission
+  purposes. By providing a set of type class instances, you can
+  also serialize any custom data type you have as well.
+  .
+  The underlying binary format used is the 'Consise Binary Object
+  Representation', or CBOR, specified in RFC 7049. As a result,
+  serialized Haskell values have implicit structure outside of the
+  Haskell program itself, meaning they can be inspected or analyzed
+  with custom tools.
 
 extra-source-files:
   tests/test-vectors/appendix_a.json
@@ -29,6 +32,7 @@ source-repository head
   type: git
   location: https://github.com/well-typed/binary-serialise-cbor.git
 
+
 --------------------------------------------------------------------------------
 -- Flags
 
@@ -36,6 +40,7 @@ flag newtime15
   default: False
   manual: False
   description: Use the new time 1.5 library
+
 
 --------------------------------------------------------------------------------
 -- Library
@@ -45,33 +50,38 @@ library
   ghc-options:       -Wall
   c-sources:         cbits/half.c
 
-  exposed-modules:   Data.Binary.Serialise.CBOR,
-                     Data.Binary.Serialise.CBOR.Class,
-                     Data.Binary.Serialise.CBOR.Decoding,
-                     Data.Binary.Serialise.CBOR.Encoding,
-                     Data.Binary.Serialise.CBOR.Read,
-                     Data.Binary.Serialise.CBOR.Write,
-                     Data.Binary.Serialise.CBOR.Term,
-                     Data.Binary.Serialise.CBOR.Tutorial
+  exposed-modules:
+    Data.Binary.Serialise.CBOR,
+    Data.Binary.Serialise.CBOR.Class,
+    Data.Binary.Serialise.CBOR.Decoding,
+    Data.Binary.Serialise.CBOR.Encoding,
+    Data.Binary.Serialise.CBOR.Read,
+    Data.Binary.Serialise.CBOR.Write,
+    Data.Binary.Serialise.CBOR.Term,
+    Data.Binary.Serialise.CBOR.Tutorial
 
-  other-modules:     Data.Binary.Serialise.CBOR.ByteOrder
+  other-modules:
+    Data.Binary.Serialise.CBOR.ByteOrder
 
-  other-extensions:  CPP, ForeignFunctionInterface, MagicHash,
-                     UnboxedTuples, BangPatterns, DeriveDataTypeable,
-                     RankNTypes
+  other-extensions:
+    CPP, ForeignFunctionInterface, MagicHash,
+    UnboxedTuples, BangPatterns, DeriveDataTypeable,
+    RankNTypes
 
-  build-depends:     base       >=4.6 && <4.9,
-                     ghc-prim   >=0.3 && <0.5,
-                     text       >=1.1 && <1.3,
-                     bytestring >= 0.10.4 && <0.11,
-                     array,
-                     binary,
-                     time
+  build-depends:
+    base       >= 4.6     && <4.9,
+    ghc-prim   >= 0.3     && <0.5,
+    text       >= 1.1     && <1.3,
+    bytestring >= 0.10.4  && <0.11,
+    array,
+    binary,
+    time
 
   if flag(newtime15)
-    build-depends:   time >= 1.5
+    build-depends: time >= 1.5
   else
-    build-depends:   time < 1.5, old-locale
+    build-depends: time < 1.5, old-locale
+
 
 --------------------------------------------------------------------------------
 -- Tests
@@ -84,34 +94,36 @@ test-suite tests
   ghc-options:       -Wall
   c-sources:         cbits/half.c
 
+  other-modules:
+    ReferenceImpl,
+    ReferenceTests,
+    CBORTests
 
-  other-modules:     ReferenceImpl,
-                     ReferenceTests,
-                     CBORTests
-
-  build-depends:     base, ghc-prim,
-                     bytestring,
-                     base64-bytestring,
-                     base16-bytestring,
-                     text,
-                     array,
-                     time >=1.4,
-                     deepseq,
-                     scientific,
-                     vector,
-                     aeson  >=0.7 && <0.9,
-                     half,
-                     binary >=0.7 && <0.8,
-                   --msgpack,
-                     tasty,
-                     tasty-hunit,
-                     tasty-quickcheck,
-                     QuickCheck >= 2
+  build-depends:
+    base, ghc-prim,
+    bytestring,
+    base64-bytestring,
+    base16-bytestring,
+    text,
+    array,
+    time >=1.4,
+    deepseq,
+    scientific,
+    vector,
+    aeson  >=0.7 && <0.9,
+    half,
+    binary >=0.7 && <0.8,
+  --msgpack,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    QuickCheck >= 2
 
   if flag(newtime15)
     build-depends:   time >= 1.5
   else
     build-depends:   time < 1.5, old-locale
+
 
 --------------------------------------------------------------------------------
 -- Benchmarks
@@ -124,45 +136,47 @@ benchmark vs-other-libs
   ghc-options:       -Wall -rtsopts
   c-sources:         cbits/half.c
 
-  other-modules:     Real.Types,
-                     Real.Load,
-                     Real.DeepSeq,
-                     Real.MemSize,
-                     Real.ReadShow,
-                     Real.PkgAesonGeneric,
-                     Real.PkgAesonTH,
-                     Real.PkgBinary,
-                     Real.PkgCereal,
-                   --Real.PkgMsgpack,
-                     Real.CBOR,
+  other-modules:
+    Real.Types,
+    Real.Load,
+    Real.DeepSeq,
+    Real.MemSize,
+    Real.ReadShow,
+    Real.PkgAesonGeneric,
+    Real.PkgAesonTH,
+    Real.PkgBinary,
+    Real.PkgCereal,
+  --Real.PkgMsgpack,
+    Real.CBOR,
 
-                     Tree.Types,
-                     Tree.Load,
-                     Tree.DeepSeq,
-                     Tree.MemSize,
-                     Tree.ReadShow,
-                     Tree.PkgAesonGeneric,
-                     Tree.PkgAesonTH,
-                     Tree.PkgBinary,
-                     Tree.PkgCereal,
-                   --Tree.PkgMsgpack,
-                     Tree.CBOR
+    Tree.Types,
+    Tree.Load,
+    Tree.DeepSeq,
+    Tree.MemSize,
+    Tree.ReadShow,
+    Tree.PkgAesonGeneric,
+    Tree.PkgAesonTH,
+    Tree.PkgBinary,
+    Tree.PkgCereal,
+  --Tree.PkgMsgpack,
+    Tree.CBOR
 
-  build-depends:     base, ghc-prim,
-                     text, bytestring, deepseq,
-                     aeson  >=0.7,
-                     binary ==0.7.*,
-                     cereal ==0.4.*,
---                   msgpack == 0.7.*, blaze-builder, attoparsec,
-                     containers >=0.5,
-                     array,
-                     half,
-                     filepath,
-                     tar  >=0.4,
-                     zlib >=0.5,
-                     pretty,
-                     time >=1.4,
-                     criterion
+  build-depends:
+    base, ghc-prim,
+    text, bytestring, deepseq,
+    aeson  >=0.7,
+    binary ==0.7.*,
+    cereal ==0.4.*,
+  --msgpack == 0.7.*, blaze-builder, attoparsec,
+    containers >=0.5,
+    array,
+    half,
+    filepath,
+    tar  >=0.4,
+    zlib >=0.5,
+    pretty,
+    time >=1.4,
+    criterion
 
   if flag(newtime15)
     build-depends:   time >= 1.5

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -55,6 +55,7 @@ library
     Data.Binary.Serialise.CBOR.Class,
     Data.Binary.Serialise.CBOR.Decoding,
     Data.Binary.Serialise.CBOR.Encoding,
+    Data.Binary.Serialise.CBOR.IO
     Data.Binary.Serialise.CBOR.Read,
     Data.Binary.Serialise.CBOR.Write,
     Data.Binary.Serialise.CBOR.Term,


### PR DESCRIPTION
This does a few more little clean ups.

  - Move some `IO` based routines to a fancy new `.IO` module like all the cool new packages do.
  - Styling of the source. I used `stylish-haskell` to make several modules have the imports better aligned, but I haven't done this to every module. In general I think automated styling of this stuff would be nice, though.
  - Reformatted the `.cabal` file a little.
  - Added some very basic documentation, but the top-level module already looks better.
  - Add some whitespace. But also, delete some whitespace too.