### PR TITLE
Expose FlatTerm module and implement some missing bits

### DIFF
--- a/Data/Binary/Serialise/CBOR/FlatTerm.hs
+++ b/Data/Binary/Serialise/CBOR/FlatTerm.hs
@@ -146,7 +146,7 @@ fromFlatTerm decoder =
     go (ConsumeWord k)    (TkInt     n : ts)
         | n >= 0                             = go (k (unW# (fromIntegral n))) ts
     go (ConsumeNegWord k) (TkInt     n : ts)
-        | n <  0                             = go (k (unW# (fromIntegral (-n)))) ts
+        | n <  0                             = go (k (unW# (fromIntegral (-1-n)))) ts
     go (ConsumeInt k)     (TkInt     n : ts) = go (k (unI# n)) ts
     go (ConsumeInteger k) (TkInt     n : ts) = go (k (fromIntegral n)) ts
     go (ConsumeInteger k) (TkInteger n : ts) = go (k n) ts

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -55,6 +55,7 @@ library
     Data.Binary.Serialise.CBOR.Class,
     Data.Binary.Serialise.CBOR.Decoding,
     Data.Binary.Serialise.CBOR.Encoding,
+    Data.Binary.Serialise.CBOR.FlatTerm,
     Data.Binary.Serialise.CBOR.IO
     Data.Binary.Serialise.CBOR.Read,
     Data.Binary.Serialise.CBOR.Write,


### PR DESCRIPTION
This makes it possible to use `FlatTerm` (typically for QC properties) in client code. I added a missing case to `fromFlatTerm`, and fixed what looks like an off-by-one error (although I'm not completely sure that this is the right place to fix it).