### PR TITLE
Don't use intermediate list in decodeContainerSkel

### DIFF
--- a/Data/Binary/Serialise/CBOR/Decoding.hs
+++ b/Data/Binary/Serialise/CBOR/Decoding.hs
@@ -65,6 +65,7 @@ module Data.Binary.Serialise.CBOR.Decoding
 
   -- ** Inspecting the token type
   , peekTokenType        -- :: Decoder TokenType
+  , peekLength           -- :: Decoder Int
   , TokenType(..)
 
   -- ** Special operations
@@ -141,6 +142,7 @@ data DecodeAction a
     | ConsumeBreakOr        (Bool -> DecodeAction a)
 
     | PeekTokenType  (TokenType -> DecodeAction a)
+    | PeekLength     (Int -> DecodeAction a)
 
     | Fail String
     | Done a
@@ -440,6 +442,10 @@ decodeBreakOr = Decoder (\k -> ConsumeBreakOr (\b -> k b))
 peekTokenType :: Decoder TokenType
 peekTokenType = Decoder (\k -> PeekTokenType (\tk -> k tk))
 {-# INLINE peekTokenType #-}
+
+{-# INLINE peekLength #-}
+peekLength :: Decoder Int
+peekLength = Decoder (\k -> PeekLength (\len -> k len))
 
 {-
 expectExactly :: Word -> Decoder (Word :#: s) s

--- a/Data/Binary/Serialise/CBOR/FlatTerm.hs
+++ b/Data/Binary/Serialise/CBOR/FlatTerm.hs
@@ -231,6 +231,7 @@ fromFlatTerm decoder ft = go (getDecodeAction decoder) ft
 
     go (PeekTokenType k) ts@(tk:_) = go (k (tokenTypeOf tk)) ts
     go (PeekTokenType _) ts        = unexpected "peekTokenType" ts
+    go (PeekLength k) ts           = go (k (length ts)) ts
 
     go (Fail msg) _  = Left msg
     go (Done x)   [] = Right x

--- a/Data/Binary/Serialise/CBOR/Read.hs
+++ b/Data/Binary/Serialise/CBOR/Read.hs
@@ -361,6 +361,8 @@ go_fast (PeekTokenType k) !bs =
         !tkty = decodeTokenTypeTable `A.unsafeAt` fromIntegral hdr
     in go_fast (k tkty) bs
 
+go_fast (PeekLength k) !bs = go_fast (k $! BS.length bs) bs
+
 go_fast da@Fail{} !bs = go_fast_end da bs
 go_fast da@Done{} !bs = go_fast_end da bs
 
@@ -374,10 +376,11 @@ go_fast da@Done{} !bs = go_fast_end da bs
 --
 go_fast_end :: DecodeAction a -> ByteString -> SlowPath a
 
--- these two cases don't need any input
+-- these three cases don't need any input
 
 go_fast_end (Fail msg) !bs = SlowFail bs msg
 go_fast_end (Done x)   !bs = FastDone bs x
+go_fast_end (PeekLength k) !bs = go_fast_end (k $! BS.length bs) bs
 
 -- the next two cases only need the 1 byte token header
 go_fast_end da !bs | BS.null bs = SlowDecodeAction bs da


### PR DESCRIPTION
As I've mentioned in the commit description, this doesn't seem to change benchmark results. But it still seems that the code is a bit more readable.