### PR TITLE
Inline vector encoders and decoders

### DIFF
--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -292,10 +292,12 @@ instance (Serialise a) => Serialise (Vector.Vector a) where
              Vector.length
              Vector.foldr
              (\a b -> encode a <> b)
+  {-# INLINE encode #-}
   decode = decodeContainerSkel
              decodeListLen
              Vector.fromListN
              decode
+  {-# INLINE decode #-}
 
 --TODO: we really ought to be able to do better than going via lists,
 -- especially for unboxed vectors
@@ -306,10 +308,12 @@ instance (Serialise a, Vector.Unboxed.Unbox a) =>
              Vector.Unboxed.length
              Vector.Unboxed.foldr
              (\a b -> encode a <> b)
+  {-# INLINE encode #-}
   decode = decodeContainerSkel
              decodeListLen
              Vector.Unboxed.fromListN
              decode
+  {-# INLINE decode #-}
 
 
 encodeSetSkel :: Serialise a

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ into `ByteString`s for storage or transmission purposes. By providing a set of
 type class instances, you can also serialize any custom data type you have as
 well.
 
-The underlying binary format used is the 'Consise Binary Object
+The underlying binary format used is the 'Concise Binary Object
 Representation', or CBOR, specified in `RFC 7049`. As a result, serialized
 Haskell values have implicit structure outside of the Haskell program itself,
 meaning they can be inspected or analyzed with custom tools.

--- a/bench/Instances.hs
+++ b/bench/Instances.hs
@@ -1,10 +1,45 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Instances
   ( benchmarks -- :: [Benchmark]
   ) where
 
+import           Data.Proxy
 import           Criterion.Main
+import qualified Data.Vector.Generic as VG
+import qualified Data.Vector.Unboxed as VU
+import qualified Data.Vector as V
+import qualified Data.ByteString.Lazy as BSL
+import           Data.Binary.Serialise.CBOR
+import           Control.DeepSeq (force)
 
 benchmarks :: [Benchmark]
 benchmarks =
-  [
+  [ bgroup "unboxed"
+      [ vector unboxed (42 :: Int) 500
+      , vector unboxed (42 :: Int) 5000
+      , vector unboxed (42 :: Int) 50000
+      , vector unboxed (42 :: Int) 500000
+      ]
+  , bgroup "boxed"
+      [ vector boxed (42 :: Int) 500
+      , vector boxed (42 :: Int) 5000
+      , vector boxed (42 :: Int) 50000
+      , vector boxed (42 :: Int) 500000
+      ]
   ]
+  where
+    unboxed = Proxy :: Proxy VU.Vector
+    boxed   = Proxy :: Proxy V.Vector
+
+vector :: forall v a. (Serialise (v a), VG.Vector v a, Num a)
+       => Proxy v -> a -> Int -> Benchmark
+vector Proxy x len = bgroup ("n="++show len)
+    [ bench "encode" $ benchEncode (asVector $ VG.replicate len x)
+    , bench "decode" $ whnf (VG.sum . asVector . deserialise) (force $ serialise $ asVector $ VG.replicate len x)
+    ]
+  where asVector v = v :: v a
+
+benchEncode :: Serialise a => a -> Benchmarkable
+benchEncode = whnf (BSL.length . serialise)
+{-# INLINE benchEncode #-}

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -18,7 +18,7 @@ description:
   purposes. By providing a set of type class instances, you can
   also serialize any custom data type you have as well.
   .
-  The underlying binary format used is the 'Consise Binary Object
+  The underlying binary format used is the 'Concise Binary Object
   Representation', or CBOR, specified in RFC 7049. As a result,
   serialized Haskell values have implicit structure outside of the
   Haskell program itself, meaning they can be inspected or analyzed

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -243,6 +243,7 @@ benchmark vs-other-libs
     directory               >= 1.0     && < 1.3,
     ghc-prim                >= 0.3     && < 0.6,
     text                    >= 1.1     && < 1.3,
+    vector                  >= 0.10    && < 1.0,
     binary-serialise-cbor,
 
     filepath                >= 1.0     && < 1.5,


### PR DESCRIPTION
The `Vector` encoders and decoders should be inline lest we are forced to dynamically dispatch various calls through a ``Data.Vector.Generic.Vector` dictionary, which has a rather drastic effect on performance,

benchmark                                              |        before |                  |       after    |                  |     delta
------------------------------------------------------ |-------------- | ---------------- | -------------- | ---------------- | -----------
boxed/n=500/decode                                     |        28.23  | ±       0.8 μs   |          26.7  | ±      1.00 μs   |     -5.5%
boxed/n=500/encode                                     |        23.54  | ±       1.2 μs   |          11.5  | ±      0.41 μs   |     -51.0%
boxed/n=5000/decode                                    |       487.68  | ±      21.4 μs   |         481.4  | ±     48.74 μs   |     -1.3%
boxed/n=5000/encode                                    |       237.79  | ±      11.2 μs   |         112.6  | ±      3.90 μs   |     -52.7%
boxed/n=50000/decode                                   |      9000.91  | ±     763.0 μs   |        8472.4  | ±    352.90 μs   |     -5.9%
boxed/n=50000/encode                                   |      2573.48  | ±     321.2 μs   |        1255.5  | ±     91.90 μs   |     -51.2%
boxed/n=500000/decode                                  |    116484.39  | ±   25379.6 μs   |       98732.9  | ±   3584.60 μs   |     -15.2%
boxed/n=500000/encode                                  |     24388.84  | ±    1143.1 μs   |       12165.4  | ±    418.13 μs   |     -50.1%
unboxed/n=500/decode                                   |        47.30  | ±       4.2 μs   |          27.0  | ±      0.65 μs   |     -42.8%
unboxed/n=500/encode                                   |        33.28  | ±       5.5 μs   |          11.1  | ±      1.43 μs   |     -66.6%
unboxed/n=5000/decode                                  |       745.26  | ±      19.5 μs   |         463.9  | ±     13.53 μs   |     -37.7%
unboxed/n=5000/encode                                  |       329.08  | ±       8.0 μs   |         106.2  | ±      3.31 μs   |     -67.7%
unboxed/n=50000/decode                                 |     11070.82  | ±     343.4 μs   |        8660.3  | ±    358.24 μs   |     -21.8%
unboxed/n=50000/encode                                 |      3220.04  | ±      76.6 μs   |        1124.1  | ±     54.28 μs   |     -65.1%
unboxed/n=500000/decode                                |    115083.09  | ±    3525.2 μs   |       97234.6  | ±   3125.91 μs   |     -15.5%
unboxed/n=500000/encode                                |     32053.50  | ±     569.1 μs   |       10564.2  | ±    214.81 μs   |     -67.0%

