### PR TITLE
Removed MINIMAL pragma from class definition.

### DIFF
--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -77,8 +77,6 @@ import           Data.Binary.Serialise.CBOR.Encoding
 -- to be quickly encoded or decoded directly to a CBOR representation,
 -- for object transmission or storage.
 class Serialise a where
-    {-# MINIMAL encode, decode #-}
-
     -- | Definition for encoding a given type into a binary
     -- representation, using the @'Encoding'@ @'Monoid'@.
     encode  :: a -> Encoding


### PR DESCRIPTION
Removes the MINIMAL pragma from `Serialise` class - when `Generic` default methods are defined, it doesn't work as intended and only generates warning.
Closes #44 