### PR TITLE
Add instances for most data types from base

### DIFF
--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -35,7 +35,9 @@ import           Data.Word
 import           Data.Complex
 import           Data.Ratio
 import           Data.Ord
+#if MIN_VERSION_base(4,8,0)
 import           Data.Functor.Identity
+#endif
 import qualified Data.Foldable                       as Foldable
 import qualified Data.ByteString                     as BS
 import qualified Data.Text                           as Text
@@ -283,9 +285,11 @@ instance Serialise (f a) => Serialise (Alt f a) where
     encode (Alt b) = encode b
     decode = Alt <$> decode
 
+#if MIN_VERSION_base(4,8,0)
 instance Serialise a => Serialise (Identity a) where
     encode (Identity b) = encode b
     decode = Identity <$> decode
+#endif
 
 instance Serialise ExitCode where
     encode ExitSuccess     = encodeListLen 1

--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -52,6 +52,7 @@ import qualified Data.HashMap.Strict                 as HashMap
 import qualified Data.Vector                         as Vector
 import qualified Data.Vector.Unboxed                 as Vector.Unboxed
 --import qualified Data.Text.Lazy                      as Text.Lazy
+import           Foreign.C.Types
 
 import           Data.Time                           (UTCTime (..))
 #if MIN_VERSION_time(1,5,0)
@@ -203,6 +204,105 @@ instance Serialise BS.ByteString where
     encode = encodeBytes
     decode = decodeBytes
 
+instance Serialise CChar where
+    encode (CChar x) = encode x
+    decode = CChar <$> decode
+
+instance Serialise CSChar where
+    encode (CSChar x) = encode x
+    decode = CSChar <$> decode
+
+instance Serialise CUChar where
+    encode (CUChar x) = encode x
+    decode = CUChar <$> decode
+
+instance Serialise CShort where
+    encode (CShort x) = encode x
+    decode = CShort <$> decode
+
+instance Serialise CUShort where
+    encode (CUShort x) = encode x
+    decode = CUShort <$> decode
+
+instance Serialise CInt where
+    encode (CInt x) = encode x
+    decode = CInt <$> decode
+
+instance Serialise CUInt where
+    encode (CUInt x) = encode x
+    decode = CUInt <$> decode
+
+instance Serialise CLong where
+    encode (CLong x) = encode x
+    decode = CLong <$> decode
+
+instance Serialise CULong where
+    encode (CULong x) = encode x
+    decode = CULong <$> decode
+
+instance Serialise CPtrdiff where
+    encode (CPtrdiff x) = encode x
+    decode = CPtrdiff <$> decode
+
+instance Serialise CSize where
+    encode (CSize x) = encode x
+    decode = CSize <$> decode
+
+instance Serialise CWchar where
+    encode (CWchar x) = encode x
+    decode = CWchar <$> decode
+
+instance Serialise CSigAtomic where
+    encode (CSigAtomic x) = encode x
+    decode = CSigAtomic <$> decode
+
+instance Serialise CLLong where
+    encode (CLLong x) = encode x
+    decode = CLLong <$> decode
+
+instance Serialise CULLong where
+    encode (CULLong x) = encode x
+    decode = CULLong <$> decode
+
+instance Serialise CIntPtr where
+    encode (CIntPtr x) = encode x
+    decode = CIntPtr <$> decode
+
+instance Serialise CUIntPtr where
+    encode (CUIntPtr x) = encode x
+    decode = CUIntPtr <$> decode
+
+instance Serialise CIntMax where
+    encode (CIntMax x) = encode x
+    decode = CIntMax <$> decode
+
+instance Serialise CUIntMax where
+    encode (CUIntMax x) = encode x
+    decode = CUIntMax <$> decode
+
+instance Serialise CClock where
+    encode (CClock x) = encode x
+    decode = CClock <$> decode
+
+instance Serialise CTime where
+    encode (CTime x) = encode x
+    decode = CTime <$> decode
+
+instance Serialise CUSeconds where
+    encode (CUSeconds x) = encode x
+    decode = CUSeconds <$> decode
+
+instance Serialise CSUSeconds where
+    encode (CSUSeconds x) = encode x
+    decode = CSUSeconds <$> decode
+
+instance Serialise CFloat where
+    encode (CFloat x) = encode x
+    decode = CFloat <$> decode
+
+instance Serialise CDouble where
+    encode (CDouble x) = encode x
+    decode = CDouble <$> decode
 
 --------------------------------------------------------------------------------
 -- Structure instances

--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -228,6 +228,80 @@ instance (Serialise a, Serialise b, Serialise c) => Serialise (a,b,c) where
                 !z <- decode
                 return (x, y, z)
 
+instance (Serialise a, Serialise b, Serialise c, Serialise d
+         ) => Serialise (a,b,c,d) where
+    encode (a,b,c,d) = encodeListLen 4
+                    <> encode a
+                    <> encode b
+                    <> encode c
+                    <> encode d
+
+    decode = do decodeListLenOf 4
+                !a <- decode
+                !b <- decode
+                !c <- decode
+                !d <- decode
+                return (a, b, c, d)
+
+instance (Serialise a, Serialise b, Serialise c, Serialise d, Serialise e
+         ) => Serialise (a,b,c,d,e) where
+    encode (a,b,c,d,e) = encodeListLen 5
+                      <> encode a
+                      <> encode b
+                      <> encode c
+                      <> encode d
+                      <> encode e
+
+    decode = do decodeListLenOf 5
+                !a <- decode
+                !b <- decode
+                !c <- decode
+                !d <- decode
+                !e <- decode
+                return (a, b, c, d, e)
+
+instance ( Serialise a, Serialise b, Serialise c, Serialise d, Serialise e
+         , Serialise f
+         ) => Serialise (a,b,c,d,e,f) where
+    encode (a,b,c,d,e,f) = encodeListLen 6
+                        <> encode a
+                        <> encode b
+                        <> encode c
+                        <> encode d
+                        <> encode e
+                        <> encode f
+
+    decode = do decodeListLenOf 6
+                !a <- decode
+                !b <- decode
+                !c <- decode
+                !d <- decode
+                !e <- decode
+                !f <- decode
+                return (a, b, c, d, e, f)
+
+instance ( Serialise a, Serialise b, Serialise c, Serialise d, Serialise e
+         , Serialise f, Serialise g
+         ) => Serialise (a,b,c,d,e,f,g) where
+    encode (a,b,c,d,e,f,g) = encodeListLen 7
+                          <> encode a
+                          <> encode b
+                          <> encode c
+                          <> encode d
+                          <> encode e
+                          <> encode f
+                          <> encode g
+
+    decode = do decodeListLenOf 7
+                !a <- decode
+                !b <- decode
+                !c <- decode
+                !d <- decode
+                !e <- decode
+                !f <- decode
+                !g <- decode
+                return (a, b, c, d, e, f, g)
+
 instance Serialise a => Serialise (Maybe a) where
     encode Nothing  = encodeListLen 0
     encode (Just x) = encodeListLen 1 <> encode x

--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -281,11 +281,11 @@ instance Serialise a => Serialise (Last a) where
     encode (Last b) = encode b
     decode = Last <$> decode
 
+#if MIN_VERSION_base(4,8,0)
 instance Serialise (f a) => Serialise (Alt f a) where
     encode (Alt b) = encode b
     decode = Alt <$> decode
 
-#if MIN_VERSION_base(4,8,0)
 instance Serialise a => Serialise (Identity a) where
     encode (Identity b) = encode b
     decode = Identity <$> decode

--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -25,15 +25,17 @@ module Data.Binary.Serialise.CBOR.Class
 
 #include "cbor.h"
 
-#if ! MIN_VERSION_base(4,8,0)
 import           Control.Applicative
-#endif
 import           Control.Monad
 import           Data.Hashable
 import           Data.Int
 import           Data.Monoid
 import           Data.Version
 import           Data.Word
+import           Data.Complex
+import           Data.Ratio
+import           Data.Ord
+import           Data.Functor.Identity
 import qualified Data.Foldable                       as Foldable
 import qualified Data.ByteString                     as BS
 import qualified Data.Text                           as Text
@@ -62,6 +64,7 @@ import           Data.Time.Format                    (defaultTimeLocale,
 import           Data.Time.Format                    (formatTime, parseTime)
 import           System.Locale                       (defaultTimeLocale)
 #endif
+import           System.Exit                         (ExitCode(..))
 
 import           Prelude hiding (decodeFloat, encodeFloat, foldr)
 import qualified Prelude
@@ -203,6 +206,107 @@ instance Serialise Text.Text where
 instance Serialise BS.ByteString where
     encode = encodeBytes
     decode = decodeBytes
+
+instance Serialise a => Serialise (Const a b) where
+    encode (Const a) = encode a
+    decode = Const <$> decode
+
+instance Serialise a => Serialise (ZipList a) where
+    encode (ZipList xs) = encode xs
+    decode = ZipList <$> decode
+
+instance (Serialise a, Integral a) => Serialise (Ratio a) where
+    encode a = encodeListLen 2
+            <> encode (numerator a)
+            <> encode (denominator a)
+    decode = do decodeListLenOf 2
+                !a <- decode
+                !b <- decode
+                return $ a % b
+
+instance Serialise a => Serialise (Complex a) where
+    encode (r :+ i) = encodeListLen 2
+                   <> encode r
+                   <> encode i
+    decode = do decodeListLenOf 2
+                !r <- decode
+                !i <- decode
+                return $ r :+ i
+
+instance Serialise Ordering where
+    encode a = encodeListLen 1
+            <> encodeWord (case a of LT -> 0
+                                     EQ -> 1
+                                     GT -> 2)
+    decode = do
+      decodeListLenOf 1
+      t <- decodeWord
+      case t of
+        0 -> return LT
+        1 -> return EQ
+        2 -> return GT
+        _ -> fail "unexpected tag"
+
+instance Serialise a => Serialise (Down a) where
+    encode (Down a) = encode a
+    decode = Down <$> decode
+
+instance Serialise a => Serialise (Dual a) where
+    encode (Dual a) = encode a
+    decode = Dual <$> decode
+
+instance Serialise All where
+    encode (All b) = encode b
+    decode = All <$> decode
+
+instance Serialise Any where
+    encode (Any b) = encode b
+    decode = Any <$> decode
+
+instance Serialise a => Serialise (Sum a) where
+    encode (Sum b) = encode b
+    decode = Sum <$> decode
+
+instance Serialise a => Serialise (Product a) where
+    encode (Product b) = encode b
+    decode = Product <$> decode
+
+instance Serialise a => Serialise (First a) where
+    encode (First b) = encode b
+    decode = First <$> decode
+
+instance Serialise a => Serialise (Last a) where
+    encode (Last b) = encode b
+    decode = Last <$> decode
+
+instance Serialise (f a) => Serialise (Alt f a) where
+    encode (Alt b) = encode b
+    decode = Alt <$> decode
+
+instance Serialise a => Serialise (Identity a) where
+    encode (Identity b) = encode b
+    decode = Identity <$> decode
+
+instance Serialise ExitCode where
+    encode ExitSuccess     = encodeListLen 1
+                          <> encodeWord 0
+    encode (ExitFailure i) = encodeListLen 2
+                          <> encodeWord 1
+                          <> encode i
+    decode = do
+      n <- decodeListLen
+      case n of
+        1 -> do t <- decodeWord
+                case t of
+                  0 -> return ExitSuccess
+                  _ -> fail "unexpected tag"
+        2 -> do t <- decodeWord
+                case t of
+                  1 -> return ()
+                  _ -> fail "unexpected tag"
+                !i <- decode
+                return $ ExitFailure i
+        _ -> fail "Bad list length"
 
 instance Serialise CChar where
     encode (CChar x) = encode x

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -21,6 +21,7 @@ import           Data.Typeable
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
 #endif
+import           Foreign.C.Types
 
 import           Test.QuickCheck
 import           Test.Tasty
@@ -122,6 +123,31 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T Float)
       , mkTest (T :: T Double)
       , mkTest (T :: T Char)
+      , mkTest (T :: T CChar)
+      , mkTest (T :: T CSChar)
+      , mkTest (T :: T CUChar)
+      , mkTest (T :: T CShort)
+      , mkTest (T :: T CUShort)
+      , mkTest (T :: T CInt)
+      , mkTest (T :: T CUInt)
+      , mkTest (T :: T CLong)
+      , mkTest (T :: T CULong)
+      , mkTest (T :: T CPtrdiff)
+      , mkTest (T :: T CSize)
+      , mkTest (T :: T CWchar)
+      , mkTest (T :: T CSigAtomic)
+      , mkTest (T :: T CLLong)
+      , mkTest (T :: T CULLong)
+      , mkTest (T :: T CIntPtr)
+      , mkTest (T :: T CUIntPtr)
+      , mkTest (T :: T CIntMax)
+      , mkTest (T :: T CUIntMax)
+      , mkTest (T :: T CClock)
+      , mkTest (T :: T CTime)
+      , mkTest (T :: T CUSeconds)
+      , mkTest (T :: T CSUSeconds)
+      , mkTest (T :: T CFloat)
+      , mkTest (T :: T CDouble)
       , mkTest (T :: T (Int, Char))
       , mkTest (T :: T (Int, Char, Bool))
       , mkTest (T :: T (Int, Char, Bool, String))
@@ -272,3 +298,102 @@ instance ( Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e
   arbitrary = return (,,,,,,)
           <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
           <*> arbitrary <*> arbitrary <*> arbitrary
+instance Arbitrary CChar where
+  arbitrary = CChar <$> arbitrary
+  shrink (CChar x) = CChar <$> shrink x
+
+instance Arbitrary CSChar where
+  arbitrary = CSChar <$> arbitrary
+  shrink (CSChar x) = CSChar <$> shrink x
+
+instance Arbitrary CUChar where
+  arbitrary = CUChar <$> arbitrary
+  shrink (CUChar x) = CUChar <$> shrink x
+
+instance Arbitrary CShort where
+  arbitrary = CShort <$> arbitrary
+  shrink (CShort x) = CShort <$> shrink x
+
+instance Arbitrary CUShort where
+  arbitrary = CUShort <$> arbitrary
+  shrink (CUShort x) = CUShort <$> shrink x
+
+instance Arbitrary CInt where
+  arbitrary = CInt <$> arbitrary
+  shrink (CInt x) = CInt <$> shrink x
+
+instance Arbitrary CUInt where
+  arbitrary = CUInt <$> arbitrary
+  shrink (CUInt x) = CUInt <$> shrink x
+
+instance Arbitrary CLong where
+  arbitrary = CLong <$> arbitrary
+  shrink (CLong x) = CLong <$> shrink x
+
+instance Arbitrary CULong where
+  arbitrary = CULong <$> arbitrary
+  shrink (CULong x) = CULong <$> shrink x
+
+instance Arbitrary CPtrdiff where
+  arbitrary = CPtrdiff <$> arbitrary
+  shrink (CPtrdiff x) = CPtrdiff <$> shrink x
+
+instance Arbitrary CSize where
+  arbitrary = CSize <$> arbitrary
+  shrink (CSize x) = CSize <$> shrink x
+
+instance Arbitrary CWchar where
+  arbitrary = CWchar <$> arbitrary
+  shrink (CWchar x) = CWchar <$> shrink x
+
+instance Arbitrary CSigAtomic where
+  arbitrary = CSigAtomic <$> arbitrary
+  shrink (CSigAtomic x) = CSigAtomic <$> shrink x
+
+instance Arbitrary CLLong where
+  arbitrary = CLLong <$> arbitrary
+  shrink (CLLong x) = CLLong <$> shrink x
+
+instance Arbitrary CULLong where
+  arbitrary = CULLong <$> arbitrary
+  shrink (CULLong x) = CULLong <$> shrink x
+
+instance Arbitrary CIntPtr where
+  arbitrary = CIntPtr <$> arbitrary
+  shrink (CIntPtr x) = CIntPtr <$> shrink x
+
+instance Arbitrary CUIntPtr where
+  arbitrary = CUIntPtr <$> arbitrary
+  shrink (CUIntPtr x) = CUIntPtr <$> shrink x
+
+instance Arbitrary CIntMax where
+  arbitrary = CIntMax <$> arbitrary
+  shrink (CIntMax x) = CIntMax <$> shrink x
+
+instance Arbitrary CUIntMax where
+  arbitrary = CUIntMax <$> arbitrary
+  shrink (CUIntMax x) = CUIntMax <$> shrink x
+
+instance Arbitrary CClock where
+  arbitrary = CClock <$> arbitrary
+  shrink (CClock x) = CClock <$> shrink x
+
+instance Arbitrary CTime where
+  arbitrary = CTime <$> arbitrary
+  shrink (CTime x) = CTime <$> shrink x
+
+instance Arbitrary CUSeconds where
+  arbitrary = CUSeconds <$> arbitrary
+  shrink (CUSeconds x) = CUSeconds <$> shrink x
+
+instance Arbitrary CSUSeconds where
+  arbitrary = CSUSeconds <$> arbitrary
+  shrink (CSUSeconds x) = CSUSeconds <$> shrink x
+
+instance Arbitrary CFloat where
+  arbitrary = CFloat <$> arbitrary
+  shrink (CFloat x) = CFloat <$> shrink x
+
+instance Arbitrary CDouble where
+  arbitrary = CDouble <$> arbitrary
+  shrink (CDouble x) = CDouble <$> shrink x

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -124,6 +124,10 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T Char)
       , mkTest (T :: T (Int, Char))
       , mkTest (T :: T (Int, Char, Bool))
+      , mkTest (T :: T (Int, Char, Bool, String))
+      , mkTest (T :: T (Int, Char, Bool, String, ()))
+      , mkTest (T :: T (Int, Char, Bool, String, (), Maybe Char))
+      , mkTest (T :: T (Int, Char, Bool, String, (), Maybe Char, Maybe ()))
       , mkTest (T :: T (Maybe Int))
       , mkTest (T :: T (Either String Int))
       , mkTest (T :: T String)
@@ -244,3 +248,27 @@ instance Arbitrary a => Arbitrary (List a) where
       where
         cnv :: [a] -> List a
         cnv = foldr Cons Nil
+
+
+-- QC Orphans
+instance ( Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e
+         , Arbitrary f
+         )
+      => Arbitrary (a,b,c,d,e,f)
+ where
+  arbitrary = return (,,,,,)
+          <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+          <*> arbitrary <*> arbitrary
+
+  shrink (u, v, w, x, y, z) =
+    [ (u', v', w', x', y', z')
+    | (u', (v', (w', (x', (y', z'))))) <- shrink (u, (v, (w, (x, (y, z))))) ]
+
+instance ( Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e
+         , Arbitrary f, Arbitrary g
+         )
+      => Arbitrary (a,b,c,d,e,f,g)
+ where
+  arbitrary = return (,,,,,,)
+          <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+          <*> arbitrary <*> arbitrary <*> arbitrary

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
 module Tests.Serialise
   ( testTree   -- :: TestTree
   , testFormat -- :: TestTree
@@ -486,4 +487,18 @@ instance Arbitrary (f a) => Arbitrary (Alt f a) where
 instance Arbitrary a => Arbitrary (Identity a) where
   arbitrary = fmap Identity arbitrary
   shrink (Identity a) = map Identity $ shrink a
+#endif
+
+#if !MIN_VERSION_base(4,8,0)
+deriving instance Typeable Const
+deriving instance Typeable ZipList
+deriving instance Typeable Down
+deriving instance Typeable Sum
+deriving instance Typeable All
+deriving instance Typeable Any
+deriving instance Typeable Product
+deriving instance Typeable Dual
+
+deriving instance Show a => Show (Const a b)
+deriving instance Eq a   => Eq   (Const a b)
 #endif

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -294,7 +294,14 @@ instance Arbitrary a => Arbitrary (List a) where
         cnv = foldr Cons Nil
 
 
+--------------------------------------------------------------------------------
 -- QC Orphans
+--
+-- A _LOT_ of orphans instances for QuickCheck. Some are already in
+-- git HEAD and some are still waiting as pull request
+--
+-- [https://github.com/nick8325/quickcheck/pull/90]
+
 instance ( Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d, Arbitrary e
          , Arbitrary f
          )

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
@@ -22,8 +23,8 @@ import           GHC.Float (float2Double)
 import           Data.Version
 
 import           Data.Typeable
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
+#if MIN_VERSION_base(4,8,0)
+import           Data.Functor.Identity
 #endif
 import           Foreign.C.Types
 
@@ -177,6 +178,10 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T (Dual (Maybe (Sum Int))))
       , mkTest (T :: T All)
       , mkTest (T :: T Any)
+#if MIN_VERSION_base(4,8,0)
+      , mkTest (T :: T (Alt Maybe Int))
+      , mkTest (T :: T (Identity ()))
+#endif
       , mkTest (T :: T (Sum Int))
       , mkTest (T :: T (Product Int))
       , mkTest (T :: T (Map.Map Int String))
@@ -472,3 +477,13 @@ instance Arbitrary ExitCode where
 
   shrink (ExitFailure x) = ExitSuccess : [ ExitFailure x' | x' <- shrink x ]
   shrink _        = []
+
+#if MIN_VERSION_base(4,8,0)
+instance Arbitrary (f a) => Arbitrary (Alt f a) where
+  arbitrary = fmap Alt arbitrary
+  shrink (Alt a) = map Alt $ shrink a
+
+instance Arbitrary a => Arbitrary (Identity a) where
+  arbitrary = fmap Identity arbitrary
+  shrink (Identity a) = map Identity $ shrink a
+#endif


### PR DESCRIPTION
Up to 7-element tuples and about everything that could be serialized from base.

Newtype wrappers for selecting instances (like `Data.Monoid.Sum` etc) are serialized like underlying types since they aren't going to change.

There're a _LOT_ of orphan instances for QuickCheck. Some are already in
git HEAD and some are still waiting as pull request for QC, So they could be removed some time in the future.