### PR TITLE
RFC special case for GMP's Integer in Write.hs

### DIFF
--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -48,12 +48,19 @@ flag examples
   manual: True
   description: Build example programs
 
+flag optimized_gmp
+  default: True
+  manual: False
+  description: Use code optimized for recent integer-gmp.
+
 --------------------------------------------------------------------------------
 -- Library
 
 library
   default-language:  Haskell2010
   ghc-options:       -Wall
+  if flag(optimized_gmp)
+    cpp-options:     -DOPTIMIZED_GMP
   c-sources:         cbits/half.c
   include-dirs:      cbits
 
@@ -85,7 +92,8 @@ library
     containers              >= 0.5     && < 0.6,
     unordered-containers    >= 0.2     && < 0.3,
     hashable                >= 1.2     && < 2.0,
-    vector
+    vector,
+    integer-gmp            
 
   if flag(newtime15)
     build-depends:


### PR DESCRIPTION
This is probably not quite ready to merging, since there are some remaining questions:

- Should this implementation be protected by an `ifdef` and a flag in a cabal file?

- Where do we put the benchmarks for `Integer`? For now `micro/` seemed most appropriate, but I'm open to suggestions.

- Do we want to have `Integer` benchmarks using the other libraries?

Answers/comments are welcome :-)