### PR TITLE
Add Serialise instance to Data.Fixed.Fixed

### DIFF
--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -35,6 +35,7 @@ import           Data.Monoid
 import           Data.Version
 import           Data.Word
 import           Data.Complex
+import           Data.Fixed
 import           Data.Ratio
 import           Data.Ord
 
@@ -192,6 +193,14 @@ instance Serialise Float where
 instance Serialise Double where
     encode = encodeDouble
     decode = decodeDouble
+
+#if MIN_VERSION_base(4,7,0)
+-- | Values are serialised in units of least precision represented as
+--   @Integer@.
+instance HasResolution e => Serialise (Fixed e) where
+    encode (MkFixed i) = encode i
+    decode = MkFixed <$> decode
+#endif
 
 instance Serialise Char where
     encode c = encodeString (Text.singleton c)

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -15,6 +15,7 @@ import           Data.Functor.Identity
 
 import           Data.Complex
 import           Data.Int
+import           Data.Fixed
 import           Data.Monoid as Monoid
 import           Data.Ord
 import           Data.Ratio
@@ -27,9 +28,9 @@ import           Data.Typeable
 import           Control.Applicative
 import           Foreign.C.Types
 
-import           Test.QuickCheck
+import           Test.QuickCheck  hiding (Fixed(..))
 import           Test.Tasty
-import           Test.Tasty.QuickCheck
+import           Test.Tasty.QuickCheck hiding (Fixed(..))
 import           Test.QuickCheck.Instances ()
 import           Test.Tasty.HUnit
 import           GHC.Generics  (Generic)
@@ -126,6 +127,15 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T Integer)
       , mkTest (T :: T Float)
       , mkTest (T :: T Double)
+#if MIN_VERSION_base(4,7,0)
+      , mkTest (T :: T (Fixed E0))
+      , mkTest (T :: T (Fixed E1))
+      , mkTest (T :: T (Fixed E2))
+      , mkTest (T :: T (Fixed E3))
+      , mkTest (T :: T (Fixed E6))
+      , mkTest (T :: T (Fixed E9))
+      , mkTest (T :: T (Fixed E12))
+#endif
       , mkTest (T :: T Char)
       , mkTest (T :: T CChar)
       , mkTest (T :: T CSChar)


### PR DESCRIPTION
Only GHC 7.8+ is supported. Instance and tests are wrapped in CPP so it should be removed when GHC 7.6 is dropped