### PR TITLE
Write: Integer encoding specialized for integer-gmp

### DIFF
--- a/bench/instances/Instances/Integer.hs
+++ b/bench/instances/Instances/Integer.hs
@@ -18,5 +18,5 @@ benchmarks =
   where
     go = BS.length . serialise
     integerDataSmall = Vector.replicate (100 :: Int) (10 :: Integer)
-    integerDataLarge = Vector.replicate (100 :: Int) ((2 :: Integer)^(70 :: Integer))
+    integerDataLarge = Vector.replicate (100 :: Int) ((2 :: Integer)^(200 :: Integer))
 


### PR DESCRIPTION
This implements serializing an Integer using internals of
integer-gmp. This is far more efficient, especially for large
Integers (for ~70 bit Integer the improvements are not that
large: ~32 us vs ~24us, but for ~200 bit Integer they become
more pronounced: 108us vs 28us).

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>