### PR TITLE
Fix warnings

### DIFF
--- a/Data/Binary/Serialise/CBOR/Read.hs
+++ b/Data/Binary/Serialise/CBOR/Read.hs
@@ -31,6 +31,10 @@ import qualified Data.Binary.Get as Bin (Decoder(..))
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
 #endif
+#if defined(ARCH_32bit)
+import           GHC.Int
+#endif
+
 import           Control.Monad (ap)
 import           Data.Array.IArray
 import           Data.Array.Unboxed
@@ -46,7 +50,6 @@ import qualified Data.Text          as T
 import qualified Data.Text.Encoding as T
 import           Data.Word
 import           Data.Int
-import           GHC.Int
 import           GHC.Word
 import           GHC.Exts
 import           GHC.Float (float2Double)

--- a/bench/micro/Micro/CBOR.hs
+++ b/bench/micro/Micro/CBOR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Micro.CBOR (serialise, deserialise) where
 
@@ -9,19 +10,22 @@ import Data.Binary.Serialise.CBOR.Decoding
 import Data.Binary.Serialise.CBOR.Read
 import Data.Binary.Serialise.CBOR.Write
 import qualified Data.Binary.Get as Bin
-import Data.Word
 import Data.Monoid
-import Control.Applicative
 
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Internal as BS
 import qualified Data.ByteString.Builder as BS
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative
+import Data.Word
+#endif
+
 serialise :: Tree -> BS.ByteString
 serialise = BS.toLazyByteString . toBuilder . encode
 
 deserialise :: BS.ByteString -> Tree
-deserialise bs = feedAll (deserialiseIncremental decode) bs
+deserialise = feedAll (deserialiseIncremental decode)
   where
     feedAll (Bin.Done _ _ x)    _ = x
     feedAll (Bin.Partial k) lbs   = case lbs of
@@ -43,12 +47,19 @@ encodeCtr2 n a b = encodeListLen 3 <> encode (n :: Word) <> encode a <> encode b
 {-# INLINE decodeCtrBody0 #-}
 {-# INLINE decodeCtrBody2 #-}
 
+decodeCtrTag :: Decoder (Word, Int)
 decodeCtrTag = (\len tag -> (tag, len)) <$> decodeListLen <*> decodeWord
 
+decodeCtrBody0 :: Int -> a -> Decoder a
 decodeCtrBody0 1 f = pure f
+decodeCtrBody0 x _ = error $ "decodeCtrBody0: impossible tag " ++ show x
+
+decodeCtrBody2
+  :: (Serialise a, Serialise b) => Int -> (a -> b -> c) -> Decoder c
 decodeCtrBody2 3 f = do x1 <- decode
                         x2 <- decode
                         return (f x1 x2)
+decodeCtrBody2 x _ = error $ "decodeCtrBody2: impossible tag " ++ show x
 
 instance Serialise Tree where
   encode Leaf       = encodeCtr0 1
@@ -59,4 +70,5 @@ instance Serialise Tree where
     case t of
       1 -> decodeCtrBody0 l Leaf
       2 -> decodeCtrBody2 l Fork
+      x -> error $ "Serialise Tree: decode: impossible tag " ++ show x
 

--- a/bench/versus/Macro/PkgCereal.hs
+++ b/bench/versus/Macro/PkgCereal.hs
@@ -15,6 +15,7 @@ deserialiseNull :: BS.ByteString -> ()
 deserialiseNull bs =
     case Cereal.runGetLazy decodeListNull bs of
       Right () -> ()
+      Left e   -> error $ "PkgCereal.deserialiseNull: decoding failed: " ++ e
   where
     decodeListNull = do
       n <- get :: Get Int

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -189,6 +189,7 @@ test-suite tests
     Tests.CBOR
     Tests.IO
     Tests.Negative
+    Tests.Orphanage
     Tests.Serialise
     Tests.Regress
     Tests.Regress.Issue13


### PR DESCRIPTION
There's been a couple of unnecessary imports in the main package and a
bunch of various warnings in the benchmarking code. This fixes almost
all of them (except for bench/versus/Macro/CBOR where I decided to simply
disable the warning about missing signatures - it doesn't seem to be
that valuable in this case and would require a fair amounut of
boilerplate).

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>