### PR TITLE
Serialise instances for Proxy and Fingerprint

### DIFF
--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DefaultSignatures   #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
@@ -202,6 +203,10 @@ instance Serialise Double where
 instance HasResolution e => Serialise (Fixed e) where
     encode (MkFixed i) = encode i
     decode = MkFixed <$> decode
+
+instance Serialise (Proxy a) where
+    encode _ = encodeNull
+    decode   = Proxy <$ decodeNull
 #endif
 
 instance Serialise Char where

--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -78,6 +78,7 @@ import           System.Exit                         (ExitCode(..))
 
 import           Prelude hiding (decodeFloat, encodeFloat, foldr)
 import qualified Prelude
+import           GHC.Fingerprint.Type (Fingerprint(..))
 import           GHC.Generics
 
 import           Data.Binary.Serialise.CBOR.Decoding
@@ -719,6 +720,20 @@ instance Serialise Version where
           -> do !x <- decode
                 !y <- decode
                 return (Version x y)
+        _ -> fail "unexpected tag"
+
+instance Serialise Fingerprint where
+    encode (Fingerprint w1 w2) = encodeListLen 3
+                              <> encodeWord 0
+                              <> encode w1
+                              <> encode w2
+    decode = do
+      decodeListLenOf 3
+      tag <- decodeWord
+      case tag of
+        0 -> do !w1 <- decode
+                !w2 <- decode
+                return $! Fingerprint w1 w2
         _ -> fail "unexpected tag"
 
 --------------------------------------------------------------------------------

--- a/tests/Tests/Orphanage.hs
+++ b/tests/Tests/Orphanage.hs
@@ -7,10 +7,7 @@ module Tests.Orphanage where
 #if MIN_VERSION_base(4,8,0)
 import           Data.Functor.Identity
 #endif
-
-#if !MIN_VERSION_base(4,8,0)
 import           Data.Typeable
-#endif
 
 import           Control.Applicative
 
@@ -239,4 +236,9 @@ deriving instance Typeable Dual
 
 deriving instance Show a => Show (Const a b)
 deriving instance Eq a   => Eq   (Const a b)
+#endif
+
+#if MIN_VERSION_base(4,7,0)
+instance Arbitrary (Proxy a) where
+  arbitrary = return Proxy
 #endif

--- a/tests/Tests/Orphanage.hs
+++ b/tests/Tests/Orphanage.hs
@@ -15,6 +15,7 @@ import           Data.Ord
 import           Data.Monoid as Monoid
 import           Foreign.C.Types
 import           System.Exit (ExitCode(..))
+import           GHC.Fingerprint.Type
 
 import           Test.QuickCheck.Gen
 import           Test.QuickCheck.Arbitrary
@@ -233,6 +234,7 @@ deriving instance Typeable All
 deriving instance Typeable Any
 deriving instance Typeable Product
 deriving instance Typeable Dual
+deriving instance Typeable Fingerprint
 
 deriving instance Show a => Show (Const a b)
 deriving instance Eq a   => Eq   (Const a b)
@@ -242,3 +244,6 @@ deriving instance Eq a   => Eq   (Const a b)
 instance Arbitrary (Proxy a) where
   arbitrary = return Proxy
 #endif
+
+instance Arbitrary Fingerprint where
+  arbitrary = Fingerprint <$> arbitrary <*> arbitrary

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -135,6 +135,7 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T (Fixed E6))
       , mkTest (T :: T (Fixed E9))
       , mkTest (T :: T (Fixed E12))
+      , mkTest (T :: T (Proxy ()))
 #endif
       , mkTest (T :: T Char)
       , mkTest (T :: T CChar)

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -52,6 +52,7 @@ import qualified Data.Sequence              as Sequence
 import qualified Data.Set                   as Set
 import qualified Data.Vector                as Vector
 import qualified Data.Vector.Unboxed        as Vector.Unboxed
+import           GHC.Fingerprint.Type (Fingerprint(..))
 
 import           Tests.Orphanage()
 
@@ -176,6 +177,7 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T [Int])
       , mkTest (T :: T UTCTime)
       , mkTest (T :: T Version)
+      , mkTest (T :: T Fingerprint)
       , mkTest (T :: T ExitCode)
       , mkTest (T :: T (Ratio Integer))
       , mkTest (T :: T (Complex Double))


### PR DESCRIPTION
Here are instance for Proxy (in very unlikely case someone needs it)

I'm not sure Fingerprint is right one. It's some hash which is stored in two 64-bit words for convenience. Encoding it as bytestring makes more sense. What do you think?