### PR TITLE
Serialise instances for _all_ data types in vector

### DIFF
--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -62,6 +62,8 @@ import qualified Data.HashSet                        as HashSet
 import qualified Data.HashMap.Strict                 as HashMap
 import qualified Data.Vector                         as Vector
 import qualified Data.Vector.Unboxed                 as Vector.Unboxed
+import qualified Data.Vector.Storable                as Vector.Storable
+import qualified Data.Vector.Primitive               as Vector.Primitive
 --import qualified Data.Text.Lazy                      as Text.Lazy
 import           Foreign.C.Types
 
@@ -618,6 +620,7 @@ instance (Serialise a) => Serialise (Vector.Vector a) where
              Vector.concat
   {-# INLINE decode #-}
 
+
 instance (Serialise a, Vector.Unboxed.Unbox a) =>
          Serialise (Vector.Unboxed.Vector a) where
   encode = encodeContainerSkel
@@ -631,6 +634,33 @@ instance (Serialise a, Vector.Unboxed.Unbox a) =>
              Vector.Unboxed.replicateM
              Vector.Unboxed.concat
   {-# INLINE decode #-}
+
+instance (Serialise a, Vector.Storable.Storable a) => Serialise (Vector.Storable.Vector a) where
+  encode = encodeContainerSkel
+             encodeListLen
+             Vector.Storable.length
+             Vector.Storable.foldr
+             (\a b -> encode a <> b)
+  {-# INLINE encode #-}
+  decode = decodeContainerSkelWithReplicate
+             decodeListLen
+             Vector.Storable.replicateM
+             Vector.Storable.concat
+  {-# INLINE decode #-}
+
+instance (Serialise a, Vector.Primitive.Prim a) => Serialise (Vector.Primitive.Vector a) where
+  encode = encodeContainerSkel
+             encodeListLen
+             Vector.Primitive.length
+             Vector.Primitive.foldr
+             (\a b -> encode a <> b)
+  {-# INLINE encode #-}
+  decode = decodeContainerSkelWithReplicate
+             decodeListLen
+             Vector.Primitive.replicateM
+             Vector.Primitive.concat
+  {-# INLINE decode #-}
+
 
 
 encodeSetSkel :: Serialise a

--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -610,6 +610,8 @@ instance (Serialise a) => Serialise (Sequence.Seq a) where
              Sequence.replicateM
              mconcat
 
+-- | Generic encoder for vectors. Its intended use is to allow easy
+-- definition of 'Serialise' instances for custom vector
 encodeVector :: (Serialise a, Vector.Generic.Vector v a)
              => v a -> Encoding
 encodeVector = encodeContainerSkel
@@ -619,6 +621,8 @@ encodeVector = encodeContainerSkel
     (\a b -> encode a <> b)
 {-# INLINE encodeVector #-}
 
+-- | Generic decoder for vectors. Its intended use is to allow easy
+-- definition of 'Serialise' instances for custom vector
 decodeVector :: (Serialise a, Vector.Generic.Vector v a)
              => Decoder (v a)
 decodeVector = decodeContainerSkelWithReplicate

--- a/tests/Tests/Orphanage.hs
+++ b/tests/Tests/Orphanage.hs
@@ -22,6 +22,8 @@ import           System.Exit (ExitCode(..))
 import           Test.QuickCheck.Gen
 import           Test.QuickCheck.Arbitrary
 
+import qualified Data.Vector.Primitive      as Vector.Primitive
+
 --------------------------------------------------------------------------------
 -- QuickCheck Orphans
 
@@ -240,3 +242,8 @@ deriving instance Typeable Dual
 deriving instance Show a => Show (Const a b)
 deriving instance Eq a   => Eq   (Const a b)
 #endif
+
+
+instance (Vector.Primitive.Prim a, Arbitrary a
+         ) => Arbitrary (Vector.Primitive.Vector a) where
+    arbitrary = Vector.Primitive.fromList <$> arbitrary

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -52,6 +52,8 @@ import qualified Data.Sequence              as Sequence
 import qualified Data.Set                   as Set
 import qualified Data.Vector                as Vector
 import qualified Data.Vector.Unboxed        as Vector.Unboxed
+import qualified Data.Vector.Storable       as Vector.Storable
+import qualified Data.Vector.Primitive      as Vector.Primitive
 
 import           Tests.Orphanage()
 
@@ -201,6 +203,8 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T (HashSet.HashSet Int))
       , mkTest (T :: T (Vector.Vector Int))
       , mkTest (T :: T (Vector.Unboxed.Vector (Int,Bool)))
+      , mkTest (T :: T (Vector.Storable.Vector Int))
+      , mkTest (T :: T (Vector.Primitive.Vector Int))
       -- generics:
       , mkTest (T :: T Unit)
       , mkTest (T :: T P1)


### PR DESCRIPTION
Primitive and Storable vector were missing for some reason

I also exported encoding/decoding function for generic vectors. People do define other vector types so they are useful for defining instances for such vectors.