### PR TITLE
Make pretty printing of map k/v's clearer

### DIFF
--- a/Data/Binary/Serialise/CBOR/Pretty.hs
+++ b/Data/Binary/Serialise/CBOR/Pretty.hs
@@ -121,7 +121,7 @@ pprint = do
   nl
   term <- getTerm
   hexRep term
-  str " \t"
+  str " "
   case term of
     TkInt      i  TkEnd -> ppTkInt i
     TkInteger  i  TkEnd -> ppTkInteger i
@@ -174,15 +174,29 @@ ppTkListBegin  ::               PP ()
 ppTkListBegin = str "# list(*)" >> inc 3 >> indef pprint
 
 ppMapPairs :: PP ()
-ppMapPairs = pprint >> str " [end map key]" >> pprint >> str " [end map value]"
+ppMapPairs = do
+  nl
+  inc 3
+  indent
+  str " # key"
+  pprint
+  dec 3
+  -- str " [end map key]"
+  nl
+  inc 3
+  indent
+  str " # value"
+  pprint
+  dec 3
+  -- str " [end map value]"
 
 ppTkMapLen     :: Word       -> PP ()
 ppTkMapLen w = do
   str "# map"
   parens (shown w)
-  inc 3
+  -- inc 3
   replicateM_ (fromIntegral w) ppMapPairs
-  dec 3
+  -- dec 3
 
 ppTkMapBegin   ::               PP ()
 ppTkMapBegin = str "# map(*)" >> inc 3 >> indef ppMapPairs


### PR DESCRIPTION
This commit changes the `indef` combinator so it accepts the pretty printer of what it is indefinitely looking for - this mean that maps can annotate when a parsed value is a key or a value:

```haskell
Prelude.putStrLn . prettyHexEnc . encode $
    ( True
    , [1,2,3::Int]
    , (MP.fromList [("Hello",True),("World",False)]
    , "This is a very long sentense which should wrap"
    )
```
```

83  	# list(3)
   f5  	# bool(true)
   9f  	# list(*)
      01  	# int(1)
      02  	# int(2)
      03  	# int(3)
   ff  	# break
   82  	# list(2)
      a2  	# map(2)
         65 48 65 6c 6c 6f  	# text("Hello") [end map key]     <===
         f5  	# bool(true) [end map value]
         65 57 6f 72 6c 64  	# text("World") [end map key]
         f4  	# bool(false) [end map value]
      78 2e 54 68 69 73 20 69 73 20 61 20 76 65 72 79 
      20 6c 6f 6e 67 20 73 65 6e 74 65 6e 73 65 20 77 
      68 69 63 68 20 73 68 6f 75 6c 64 20 77 72 61 70  	# text("This is a very long sentense which should wrap")
```