### PR TITLE
Fix chunking in Vector deserialisation (fixes #80)

### DIFF
--- a/Data/Binary/Serialise/CBOR/Class.hs
+++ b/Data/Binary/Serialise/CBOR/Class.hs
@@ -725,7 +725,7 @@ decodeContainerSkelWithReplicate decodeLen replicateFun fromList = do
            let chunkSize = max limit 128
                (d, m) = size `divMod` chunkSize
                buildOne s = replicateFun s decode
-           containers <- sequence $ buildOne m : replicate d (buildOne limit)
+           containers <- sequence $ buildOne m : replicate d (buildOne chunkSize)
            return $! fromList containers
 {-# INLINE decodeContainerSkelWithReplicate #-}
 

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -195,6 +195,7 @@ test-suite tests
     Tests.Regress
     Tests.Regress.Issue13
     Tests.Regress.Issue67
+    Tests.Regress.Issue80
     Tests.Regress.FlatTerm
     Tests.Reference
     Tests.Reference.Implementation

--- a/tests/Tests/Regress.hs
+++ b/tests/Tests/Regress.hs
@@ -6,6 +6,7 @@ import           Test.Tasty
 
 import qualified Tests.Regress.Issue13  as Issue13
 import qualified Tests.Regress.Issue67  as Issue67
+import qualified Tests.Regress.Issue80  as Issue80
 import qualified Tests.Regress.FlatTerm as FlatTerm
 
 --------------------------------------------------------------------------------
@@ -16,4 +17,5 @@ testTree = testGroup "Regression tests"
   [ FlatTerm.testTree
   , Issue13.testTree
   , Issue67.testTree
+  , Issue80.testTree
   ]

--- a/tests/Tests/Regress/Issue80.hs
+++ b/tests/Tests/Regress/Issue80.hs
@@ -1,0 +1,24 @@
+module Tests.Regress.Issue80 ( testTree ) where
+
+import qualified Data.Vector.Storable       as S
+import qualified Data.ByteString            as BS
+import qualified Data.ByteString.Lazy       as BL
+import qualified Data.Binary.Serialise.CBOR as CBOR
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+repro :: Bool
+repro =
+    let evilChunker bs i =
+            -- Split strict bytestring into chunks and return as lazy one
+            let (b1, b2) = BS.splitAt i bs in BL.fromChunks [b1, b2]
+        -- Test case
+        value = [S.replicate 128 (0 :: Double)]
+        serialised  = (BS.concat . BL.toChunks . CBOR.serialise) value
+        deserialised = CBOR.deserialise . evilChunker serialised
+    in all (\i -> value == deserialised i) [1 .. BS.length serialised - 1]
+
+testTree :: TestTree
+testTree =
+    testGroup "Issue 80 - Vector chunkingd"
+        [ testCase "simple reproduction case"   (True @=? repro) ]


### PR DESCRIPTION
This fixes a silly mistake of using the wrong value when
consuming chunks of input for `Vector` deserialisation.

Big thanks to @Shimuuar for discovering this and providing
a nice test case (I've added it as one of regression tests).