### PR TITLE
Bump Stackage LTS, aeson-pretty constraint.

### DIFF
--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -126,7 +126,7 @@ executable demo-aeson
 
   build-depends:
     aeson                   >= 0.7     && < 0.12,
-    aeson-pretty            >= 0.7     && < 0.8,
+    aeson-pretty            >= 0.7     && < 0.9,
     base                    >= 4.6     && < 5.0,
     bytestring              >= 0.10.4  && < 0.11,
     filepath                >= 1.0     && < 1.5,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-6.1
+resolver: lts-7.0
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Allows binary-serialize-cbor to be built against Stackage LTS 7.0.