### PR TITLE
Convert decoder to use ST monad

### DIFF
--- a/Data/Binary/Serialise/CBOR.hs
+++ b/Data/Binary/Serialise/CBOR.hs
@@ -49,6 +49,7 @@ module Data.Binary.Serialise.CBOR
 
 #include "cbor.h"
 
+import           Control.Monad.ST
 import           System.IO                        (Handle, IOMode (..), withFile)
 import           Control.Exception                (throw, throwIO)
 
@@ -60,14 +61,6 @@ import           Data.Binary.Serialise.CBOR.Class
 import qualified Data.Binary.Serialise.CBOR.Read  as CBOR.Read
 import qualified Data.Binary.Serialise.CBOR.Write as CBOR.Write
 
-#if defined(USE_ST)
-import Control.Monad.ST
-#else
-import Control.Monad.Identity (Identity(..))
-type ST s a = Identity a
-runST :: (forall s. ST s a) -> a
-runST = runIdentity
-#endif
 
 --------------------------------------------------------------------------------
 

--- a/Data/Binary/Serialise/CBOR/Decoding.hs
+++ b/Data/Binary/Serialise/CBOR/Decoding.hs
@@ -23,49 +23,49 @@ module Data.Binary.Serialise.CBOR.Decoding
   , getDecodeAction
 
   -- ** Read input tokens
-  , decodeWord          -- :: Decoder Word
-  , decodeWord8         -- :: Decoder Word8
-  , decodeWord16        -- :: Decoder Word16
-  , decodeWord32        -- :: Decoder Word32
-  , decodeWord64        -- :: Decoder Word64
-  , decodeNegWord       -- :: Decoder Word
-  , decodeNegWord64     -- :: Decoder Word64
-  , decodeInt           -- :: Decoder Int 
-  , decodeInt8          -- :: Decoder Int8
-  , decodeInt16         -- :: Decoder Int16
-  , decodeInt32         -- :: Decoder Int32
-  , decodeInt64         -- :: Decoder Int64
-  , decodeInteger       -- :: Decoder Integer
-  , decodeFloat         -- :: Decoder Float
-  , decodeDouble        -- :: Decoder Double
-  , decodeBytes         -- :: Decoder ByteString
-  , decodeBytesIndef    -- :: Decoder ()
-  , decodeString        -- :: Decoder Text
-  , decodeStringIndef   -- :: Decoder ()
-  , decodeListLen       -- :: Decoder Int
-  , decodeListLenIndef  -- :: Decoder ()
-  , decodeMapLen        -- :: Decoder Int
-  , decodeMapLenIndef   -- :: Decoder ()
-  , decodeTag           -- :: Decoder Word
-  , decodeTag64         -- :: Decoder Word64
-  , decodeBool          -- :: Decoder Bool
-  , decodeNull          -- :: Decoder ()
-  , decodeSimple        -- :: Decoder Word8
+  , decodeWord          -- :: Decoder s Word
+  , decodeWord8         -- :: Decoder s Word8
+  , decodeWord16        -- :: Decoder s Word16
+  , decodeWord32        -- :: Decoder s Word32
+  , decodeWord64        -- :: Decoder s Word64
+  , decodeNegWord       -- :: Decoder s Word
+  , decodeNegWord64     -- :: Decoder s Word64
+  , decodeInt           -- :: Decoder s Int
+  , decodeInt8          -- :: Decoder s Int8
+  , decodeInt16         -- :: Decoder s Int16
+  , decodeInt32         -- :: Decoder s Int32
+  , decodeInt64         -- :: Decoder s Int64
+  , decodeInteger       -- :: Decoder s Integer
+  , decodeFloat         -- :: Decoder s Float
+  , decodeDouble        -- :: Decoder s Double
+  , decodeBytes         -- :: Decoder s ByteString
+  , decodeBytesIndef    -- :: Decoder s ()
+  , decodeString        -- :: Decoder s Text
+  , decodeStringIndef   -- :: Decoder s ()
+  , decodeListLen       -- :: Decoder s Int
+  , decodeListLenIndef  -- :: Decoder s ()
+  , decodeMapLen        -- :: Decoder s Int
+  , decodeMapLenIndef   -- :: Decoder s ()
+  , decodeTag           -- :: Decoder s Word
+  , decodeTag64         -- :: Decoder s Word64
+  , decodeBool          -- :: Decoder s Bool
+  , decodeNull          -- :: Decoder s ()
+  , decodeSimple        -- :: Decoder s Word8
 
   -- ** Specialised Read input token operations
-  , decodeWordOf        -- :: Word -> Decoder ()
-  , decodeListLenOf     -- :: Int -> Decoder ()
+  , decodeWordOf        -- :: Word -> Decoder s ()
+  , decodeListLenOf     -- :: Int  -> Decoder s ()
 
   -- ** Branching operations
 --, decodeBytesOrIndef
 --, decodeStringOrIndef
-  , decodeListLenOrIndef -- :: Decoder (Maybe Int)
-  , decodeMapLenOrIndef  -- :: Decoder (Maybe Int)
-  , decodeBreakOr        -- :: Decoder Bool
+  , decodeListLenOrIndef -- :: Decoder s (Maybe Int)
+  , decodeMapLenOrIndef  -- :: Decoder s (Maybe Int)
+  , decodeBreakOr        -- :: Decoder s Bool
 
   -- ** Inspecting the token type
-  , peekTokenType        -- :: Decoder TokenType
-  , peekAvailable        -- :: Decoder Int
+  , peekTokenType        -- :: Decoder s TokenType
+  , peekAvailable        -- :: Decoder s Int
   , TokenType(..)
 
   -- ** Special operations
@@ -88,6 +88,14 @@ import           Control.Applicative
 
 import           Prelude hiding (decodeFloat)
 
+#if defined(USE_ST)
+import Control.Monad.ST
+#else
+import Control.Monad.Identity (Identity(..))
+type ST s a = Identity a
+#endif
+
+
 -- | A continuation-based decoder, used for decoding values that were
 -- previously encoded using the "Data.Binary.Serialise.CBOR.Encoding"
 -- module. As @'Decoder'@ has a @'Monad'@ instance, you can easily
@@ -95,58 +103,58 @@ import           Prelude hiding (decodeFloat)
 -- logic.
 --
 -- @since 0.2.0.0
-data Decoder a = Decoder {
-       runDecoder :: forall r. (a -> DecodeAction r) -> DecodeAction r
+data Decoder s a = Decoder {
+       runDecoder :: forall r. (a -> ST s (DecodeAction s r)) -> ST s (DecodeAction s r)
      }
 
 -- | An action, representing a step for a decoder to taken and a
 -- continuation to invoke with the expected value.
 --
 -- @since 0.2.0.0
-data DecodeAction a
-    = ConsumeWord    (Word# -> DecodeAction a)
-    | ConsumeWord8   (Word# -> DecodeAction a)
-    | ConsumeWord16  (Word# -> DecodeAction a)
-    | ConsumeWord32  (Word# -> DecodeAction a)
-    | ConsumeNegWord (Word# -> DecodeAction a)
-    | ConsumeInt     (Int#  -> DecodeAction a)
-    | ConsumeInt8    (Int#  -> DecodeAction a)
-    | ConsumeInt16   (Int#  -> DecodeAction a)
-    | ConsumeInt32   (Int#  -> DecodeAction a)
-    | ConsumeListLen (Int#  -> DecodeAction a)
-    | ConsumeMapLen  (Int#  -> DecodeAction a)
-    | ConsumeTag     (Word# -> DecodeAction a)
+data DecodeAction s a
+    = ConsumeWord    (Word# -> ST s (DecodeAction s a))
+    | ConsumeWord8   (Word# -> ST s (DecodeAction s a))
+    | ConsumeWord16  (Word# -> ST s (DecodeAction s a))
+    | ConsumeWord32  (Word# -> ST s (DecodeAction s a))
+    | ConsumeNegWord (Word# -> ST s (DecodeAction s a))
+    | ConsumeInt     (Int#  -> ST s (DecodeAction s a))
+    | ConsumeInt8    (Int#  -> ST s (DecodeAction s a))
+    | ConsumeInt16   (Int#  -> ST s (DecodeAction s a))
+    | ConsumeInt32   (Int#  -> ST s (DecodeAction s a))
+    | ConsumeListLen (Int#  -> ST s (DecodeAction s a))
+    | ConsumeMapLen  (Int#  -> ST s (DecodeAction s a))
+    | ConsumeTag     (Word# -> ST s (DecodeAction s a))
 
 -- 64bit variants for 32bit machines
 #if defined(ARCH_32bit)
-    | ConsumeWord64    (Word64# -> DecodeAction a)
-    | ConsumeNegWord64 (Word64# -> DecodeAction a)
-    | ConsumeInt64     (Int64#  -> DecodeAction a)
-    | ConsumeListLen64 (Int64#  -> DecodeAction a)
-    | ConsumeMapLen64  (Int64#  -> DecodeAction a)
-    | ConsumeTag64     (Word64# -> DecodeAction a)
+    | ConsumeWord64    (Word64# -> ST s (DecodeAction s a))
+    | ConsumeNegWord64 (Word64# -> ST s (DecodeAction s a))
+    | ConsumeInt64     (Int64#  -> ST s (DecodeAction s a))
+    | ConsumeListLen64 (Int64#  -> ST s (DecodeAction s a))
+    | ConsumeMapLen64  (Int64#  -> ST s (DecodeAction s a))
+    | ConsumeTag64     (Word64# -> ST s (DecodeAction s a))
 #endif
 
-    | ConsumeInteger (Integer    -> DecodeAction a)
-    | ConsumeFloat   (Float#     -> DecodeAction a)
-    | ConsumeDouble  (Double#    -> DecodeAction a)
-    | ConsumeBytes   (ByteString -> DecodeAction a)
-    | ConsumeString  (Text       -> DecodeAction a)
-    | ConsumeBool    (Bool       -> DecodeAction a)
-    | ConsumeSimple  (Word#      -> DecodeAction a)
+    | ConsumeInteger (Integer    -> ST s (DecodeAction s a))
+    | ConsumeFloat   (Float#     -> ST s (DecodeAction s a))
+    | ConsumeDouble  (Double#    -> ST s (DecodeAction s a))
+    | ConsumeBytes   (ByteString -> ST s (DecodeAction s a))
+    | ConsumeString  (Text       -> ST s (DecodeAction s a))
+    | ConsumeBool    (Bool       -> ST s (DecodeAction s a))
+    | ConsumeSimple  (Word#      -> ST s (DecodeAction s a))
 
-    | ConsumeBytesIndef   (DecodeAction a)
-    | ConsumeStringIndef  (DecodeAction a)
-    | ConsumeListLenIndef (DecodeAction a)
-    | ConsumeMapLenIndef  (DecodeAction a)
-    | ConsumeNull         (DecodeAction a)
+    | ConsumeBytesIndef   (ST s (DecodeAction s a))
+    | ConsumeStringIndef  (ST s (DecodeAction s a))
+    | ConsumeListLenIndef (ST s (DecodeAction s a))
+    | ConsumeMapLenIndef  (ST s (DecodeAction s a))
+    | ConsumeNull         (ST s (DecodeAction s a))
 
-    | ConsumeListLenOrIndef (Int# -> DecodeAction a)
-    | ConsumeMapLenOrIndef  (Int# -> DecodeAction a)
-    | ConsumeBreakOr        (Bool -> DecodeAction a)
+    | ConsumeListLenOrIndef (Int# -> ST s (DecodeAction s a))
+    | ConsumeMapLenOrIndef  (Int# -> ST s (DecodeAction s a))
+    | ConsumeBreakOr        (Bool -> ST s (DecodeAction s a))
 
-    | PeekTokenType  (TokenType -> DecodeAction a)
-    | PeekAvailable  (Int#      -> DecodeAction a)
+    | PeekTokenType  (TokenType -> ST s (DecodeAction s a))
+    | PeekAvailable  (Int#      -> ST s (DecodeAction s a))
 
     | Fail String
     | Done a
@@ -184,12 +192,12 @@ data TokenType
   deriving (Eq, Ord, Enum, Bounded, Show)
 
 -- | @since 0.2.0.0
-instance Functor Decoder where
+instance Functor (Decoder s) where
     {-# INLINE fmap #-}
     fmap f = \d -> Decoder $ \k -> runDecoder d (k . f)
 
 -- | @since 0.2.0.0
-instance Applicative Decoder where
+instance Applicative (Decoder s) where
     {-# INLINE pure #-}
     pure = \x -> Decoder $ \k -> k x
 
@@ -198,7 +206,7 @@ instance Applicative Decoder where
                         runDecoder df (\f -> runDecoder dx (\x -> k (f x)))
 
 -- | @since 0.2.0.0
-instance Monad Decoder where
+instance Monad (Decoder s) where
     return = pure
 
     {-# INLINE (>>=) #-}
@@ -207,13 +215,13 @@ instance Monad Decoder where
     {-# INLINE (>>) #-}
     (>>) = \dm dn -> Decoder $ \k -> runDecoder dm (\_ -> runDecoder dn k)
 
-    fail msg = Decoder $ \_ -> Fail msg
+    fail msg = Decoder $ \_ -> return (Fail msg)
 
--- | Given a @'Decoder'@, give us the @'DecodeAction'@ 
+-- | Given a @'Decoder'@, give us the @'DecodeAction'@
 --
 -- @since 0.2.0.0
-getDecodeAction :: Decoder a -> DecodeAction a
-getDecodeAction (Decoder k) = k (\x -> Done x)
+getDecodeAction :: Decoder s a -> ST s (DecodeAction s a)
+getDecodeAction (Decoder k) = k (\x -> return (Done x))
 
 
 ---------------------------------------
@@ -223,222 +231,222 @@ getDecodeAction (Decoder k) = k (\x -> Done x)
 -- | Decode a @'Word'@.
 --
 -- @since 0.2.0.0
-decodeWord :: Decoder Word
-decodeWord = Decoder (\k -> ConsumeWord (\w# -> k (W# w#)))
+decodeWord :: Decoder s Word
+decodeWord = Decoder (\k -> return (ConsumeWord (\w# -> k (W# w#))))
 {-# INLINE decodeWord #-}
 
 -- | Decode a @'Word8'@.
 --
 -- @since 0.2.0.0
-decodeWord8 :: Decoder Word8
-decodeWord8 = Decoder (\k -> ConsumeWord8 (\w# -> k (W8# w#)))
+decodeWord8 :: Decoder s Word8
+decodeWord8 = Decoder (\k -> return (ConsumeWord8 (\w# -> k (W8# w#))))
 {-# INLINE decodeWord8 #-}
 
 -- | Decode a @'Word16'@.
 --
 -- @since 0.2.0.0
-decodeWord16 :: Decoder Word16
-decodeWord16 = Decoder (\k -> ConsumeWord16 (\w# -> k (W16# w#)))
+decodeWord16 :: Decoder s Word16
+decodeWord16 = Decoder (\k -> return (ConsumeWord16 (\w# -> k (W16# w#))))
 {-# INLINE decodeWord16 #-}
 
 -- | Decode a @'Word32'@.
 --
 -- @since 0.2.0.0
-decodeWord32 :: Decoder Word32
-decodeWord32 = Decoder (\k -> ConsumeWord32 (\w# -> k (W32# w#)))
+decodeWord32 :: Decoder s Word32
+decodeWord32 = Decoder (\k -> return (ConsumeWord32 (\w# -> k (W32# w#))))
 {-# INLINE decodeWord32 #-}
 
 -- | Decode a @'Word64'@.
 --
 -- @since 0.2.0.0
-decodeWord64 :: Decoder Word64
+decodeWord64 :: Decoder s Word64
 {-# INLINE decodeWord64 #-}
 decodeWord64 =
 #if defined(ARCH_64bit)
-  Decoder (\k -> ConsumeWord (\w# -> k (W64# w#)))
+  Decoder (\k -> return (ConsumeWord (\w# -> k (W64# w#))))
 #else
-  Decoder (\k -> ConsumeWord64 (\w64# -> k (W64# w64#)))
+  Decoder (\k -> return (ConsumeWord64 (\w64# -> k (W64# w64#))))
 #endif
 
 -- | Decode a negative @'Word'@.
 --
 -- @since 0.2.0.0
-decodeNegWord :: Decoder Word
-decodeNegWord = Decoder (\k -> ConsumeNegWord (\w# -> k (W# w#)))
+decodeNegWord :: Decoder s Word
+decodeNegWord = Decoder (\k -> return (ConsumeNegWord (\w# -> k (W# w#))))
 {-# INLINE decodeNegWord #-}
 
 -- | Decode a negative @'Word64'@.
 --
 -- @since 0.2.0.0
-decodeNegWord64 :: Decoder Word64
+decodeNegWord64 :: Decoder s Word64
 {-# INLINE decodeNegWord64 #-}
 decodeNegWord64 =
 #if defined(ARCH_64bit)
-  Decoder (\k -> ConsumeNegWord (\w# -> k (W64# w#)))
+  Decoder (\k -> return (ConsumeNegWord (\w# -> k (W64# w#))))
 #else
-  Decoder (\k -> ConsumeNegWord64 (\w64# -> k (W64# w64#)))
+  Decoder (\k -> return (ConsumeNegWord64 (\w64# -> k (W64# w64#))))
 #endif
 
 -- | Decode an @'Int'@.
 --
 -- @since 0.2.0.0
-decodeInt :: Decoder Int
-decodeInt = Decoder (\k -> ConsumeInt (\n# -> k (I# n#)))
+decodeInt :: Decoder s Int
+decodeInt = Decoder (\k -> return (ConsumeInt (\n# -> k (I# n#))))
 {-# INLINE decodeInt #-}
 
 -- | Decode an @'Int8'@.
 --
 -- @since 0.2.0.0
-decodeInt8 :: Decoder Int8
-decodeInt8 = Decoder (\k -> ConsumeInt8 (\w# -> k (I8# w#)))
+decodeInt8 :: Decoder s Int8
+decodeInt8 = Decoder (\k -> return (ConsumeInt8 (\w# -> k (I8# w#))))
 {-# INLINE decodeInt8 #-}
 
 -- | Decode an @'Int16'@.
 --
 -- @since 0.2.0.0
-decodeInt16 :: Decoder Int16
-decodeInt16 = Decoder (\k -> ConsumeInt16 (\w# -> k (I16# w#)))
+decodeInt16 :: Decoder s Int16
+decodeInt16 = Decoder (\k -> return (ConsumeInt16 (\w# -> k (I16# w#))))
 {-# INLINE decodeInt16 #-}
 
 -- | Decode an @'Int32'@.
 --
 -- @since 0.2.0.0
-decodeInt32 :: Decoder Int32
-decodeInt32 = Decoder (\k -> ConsumeInt32 (\w# -> k (I32# w#)))
+decodeInt32 :: Decoder s Int32
+decodeInt32 = Decoder (\k -> return (ConsumeInt32 (\w# -> k (I32# w#))))
 {-# INLINE decodeInt32 #-}
 
 -- | Decode an @'Int64'@.
 --
 -- @since 0.2.0.0
-decodeInt64 :: Decoder Int64
+decodeInt64 :: Decoder s Int64
 {-# INLINE decodeInt64 #-}
 decodeInt64 =
 #if defined(ARCH_64bit)
-  Decoder (\k -> ConsumeInt (\n# -> k (I64# n#)))
+  Decoder (\k -> return (ConsumeInt (\n# -> k (I64# n#))))
 #else
-  Decoder (\k -> ConsumeInt64 (\n64# -> k (I64# n64#)))
+  Decoder (\k -> return (ConsumeInt64 (\n64# -> k (I64# n64#))))
 #endif
 
 -- | Decode an @'Integer'@.
 --
 -- @since 0.2.0.0
-decodeInteger :: Decoder Integer
-decodeInteger = Decoder (\k -> ConsumeInteger (\n -> k n))
+decodeInteger :: Decoder s Integer
+decodeInteger = Decoder (\k -> return (ConsumeInteger (\n -> k n)))
 {-# INLINE decodeInteger #-}
 
 -- | Decode a @'Float'@.
 --
 -- @since 0.2.0.0
-decodeFloat :: Decoder Float
-decodeFloat = Decoder (\k -> ConsumeFloat (\f# -> k (F# f#)))
+decodeFloat :: Decoder s Float
+decodeFloat = Decoder (\k -> return (ConsumeFloat (\f# -> k (F# f#))))
 {-# INLINE decodeFloat #-}
 
 -- | Deocde a @'Double'@.
 --
 -- @since 0.2.0.0
-decodeDouble :: Decoder Double
-decodeDouble = Decoder (\k -> ConsumeDouble (\f# -> k (D# f#)))
+decodeDouble :: Decoder s Double
+decodeDouble = Decoder (\k -> return (ConsumeDouble (\f# -> k (D# f#))))
 {-# INLINE decodeDouble #-}
 
 -- | Decode a string of bytes as a @'ByteString'@.
 --
 -- @since 0.2.0.0
-decodeBytes :: Decoder ByteString
-decodeBytes = Decoder (\k -> ConsumeBytes (\bs -> k bs))
+decodeBytes :: Decoder s ByteString
+decodeBytes = Decoder (\k -> return (ConsumeBytes (\bs -> k bs)))
 {-# INLINE decodeBytes #-}
 
 -- | Decode a token marking the beginning of an indefinite length
 -- set of bytes.
 --
 -- @since 0.2.0.0
-decodeBytesIndef :: Decoder ()
-decodeBytesIndef = Decoder (\k -> ConsumeBytesIndef (k ()))
+decodeBytesIndef :: Decoder s ()
+decodeBytesIndef = Decoder (\k -> return (ConsumeBytesIndef (k ())))
 {-# INLINE decodeBytesIndef #-}
 
 -- | Decode a textual string as a piece of @'Text'@.
 --
 -- @since 0.2.0.0
-decodeString :: Decoder Text
-decodeString = Decoder (\k -> ConsumeString (\str -> k str))
+decodeString :: Decoder s Text
+decodeString = Decoder (\k -> return (ConsumeString (\str -> k str)))
 {-# INLINE decodeString #-}
 
 -- | Decode a token marking the beginning of an indefinite length
 -- string.
 --
 -- @since 0.2.0.0
-decodeStringIndef :: Decoder ()
-decodeStringIndef = Decoder (\k -> ConsumeStringIndef (k ()))
+decodeStringIndef :: Decoder s ()
+decodeStringIndef = Decoder (\k -> return (ConsumeStringIndef (k ())))
 {-# INLINE decodeStringIndef #-}
 
 -- | Decode the length of a list.
 --
 -- @since 0.2.0.0
-decodeListLen :: Decoder Int
-decodeListLen = Decoder (\k -> ConsumeListLen (\n# -> k (I# n#)))
+decodeListLen :: Decoder s Int
+decodeListLen = Decoder (\k -> return (ConsumeListLen (\n# -> k (I# n#))))
 {-# INLINE decodeListLen #-}
 
 -- | Decode a token marking the beginning of a list of indefinite
 -- length.
 --
 -- @since 0.2.0.0
-decodeListLenIndef :: Decoder ()
-decodeListLenIndef = Decoder (\k -> ConsumeListLenIndef (k ()))
+decodeListLenIndef :: Decoder s ()
+decodeListLenIndef = Decoder (\k -> return (ConsumeListLenIndef (k ())))
 {-# INLINE decodeListLenIndef #-}
 
 -- | Decode the length of a map.
 --
 -- @since 0.2.0.0
-decodeMapLen :: Decoder Int
-decodeMapLen = Decoder (\k -> ConsumeMapLen (\n# -> k (I# n#)))
+decodeMapLen :: Decoder s Int
+decodeMapLen = Decoder (\k -> return (ConsumeMapLen (\n# -> k (I# n#))))
 {-# INLINE decodeMapLen #-}
 
 -- | Decode a token marking the beginning of a map of indefinite
 -- length.
 --
 -- @since 0.2.0.0
-decodeMapLenIndef :: Decoder ()
-decodeMapLenIndef = Decoder (\k -> ConsumeMapLenIndef (k ()))
+decodeMapLenIndef :: Decoder s ()
+decodeMapLenIndef = Decoder (\k -> return (ConsumeMapLenIndef (k ())))
 {-# INLINE decodeMapLenIndef #-}
 
 -- | Decode an arbitrary tag and return it as a @'Word'@.
 --
 -- @since 0.2.0.0
-decodeTag :: Decoder Word
-decodeTag = Decoder (\k -> ConsumeTag (\w# -> k (W# w#)))
+decodeTag :: Decoder s Word
+decodeTag = Decoder (\k -> return (ConsumeTag (\w# -> k (W# w#))))
 {-# INLINE decodeTag #-}
 
 -- | Decode an arbitrary 64-bit tag and return it as a @'Word64'@.
 --
 -- @since 0.2.0.0
-decodeTag64 :: Decoder Word64
+decodeTag64 :: Decoder s Word64
 {-# INLINE decodeTag64 #-}
 decodeTag64 =
 #if defined(ARCH_64bit)
-  Decoder (\k -> ConsumeTag (\w# -> k (W64# w#)))
+  Decoder (\k -> return (ConsumeTag (\w# -> k (W64# w#))))
 #else
-  Decoder (\k -> ConsumeTag64 (\w64# -> k (W64# w64#)))
+  Decoder (\k -> return (ConsumeTag64 (\w64# -> k (W64# w64#))))
 #endif
 
 -- | Decode a bool.
 --
 -- @since 0.2.0.0
-decodeBool :: Decoder Bool
-decodeBool = Decoder (\k -> ConsumeBool (\b -> k b))
+decodeBool :: Decoder s Bool
+decodeBool = Decoder (\k -> return (ConsumeBool (\b -> k b)))
 {-# INLINE decodeBool #-}
 
 -- | Decode a nullary value, and return a unit value.
 --
 -- @since 0.2.0.0
-decodeNull :: Decoder ()
-decodeNull = Decoder (\k -> ConsumeNull (k ()))
+decodeNull :: Decoder s ()
+decodeNull = Decoder (\k -> return (ConsumeNull (k ())))
 {-# INLINE decodeNull #-}
 
 -- | Decode a 'simple' CBOR value and give back a @'Word8'@. You
 -- probably don't ever need to use this.
 --
 -- @since 0.2.0.0
-decodeSimple :: Decoder Word8
-decodeSimple = Decoder (\k -> ConsumeSimple (\w# -> k (W8# w#)))
+decodeSimple :: Decoder s Word8
+decodeSimple = Decoder (\k -> return (ConsumeSimple (\w# -> k (W8# w#))))
 {-# INLINE decodeSimple #-}
 
 
@@ -451,7 +459,7 @@ decodeSimple = Decoder (\k -> ConsumeSimple (\w# -> k (W8# w#)))
 --
 -- @since 0.2.0.0
 decodeWordOf :: Word -- ^ Expected value of the decoded word
-             -> Decoder ()
+             -> Decoder s ()
 decodeWordOf n = do
   n' <- decodeWord
   if n == n' then return ()
@@ -462,7 +470,7 @@ decodeWordOf n = do
 -- ensure it is exactly the specified length, or fail.
 --
 -- @since 0.2.0.0
-decodeListLenOf :: Int -> Decoder ()
+decodeListLenOf :: Int -> Decoder s ()
 decodeListLenOf len = do
   len' <- decodeListLen
   if len == len' then return ()
@@ -479,12 +487,12 @@ decodeListLenOf len = do
 -- returned, then a list of length @x@ is encoded.
 --
 -- @since 0.2.0.0
-decodeListLenOrIndef :: Decoder (Maybe Int)
+decodeListLenOrIndef :: Decoder s (Maybe Int)
 decodeListLenOrIndef =
-    Decoder (\k -> ConsumeListLenOrIndef (\n# ->
+    Decoder (\k -> return (ConsumeListLenOrIndef (\n# ->
                      if I# n# >= 0
                        then k (Just (I# n#))
-                       else k Nothing))
+                       else k Nothing)))
 {-# INLINE decodeListLenOrIndef #-}
 
 -- | Attempt to decode a token for the length of a finite, known map,
@@ -493,12 +501,12 @@ decodeListLenOrIndef =
 -- then a map of length @x@ is encoded.
 --
 -- @since 0.2.0.0
-decodeMapLenOrIndef :: Decoder (Maybe Int)
+decodeMapLenOrIndef :: Decoder s (Maybe Int)
 decodeMapLenOrIndef =
-    Decoder (\k -> ConsumeMapLenOrIndef (\n# ->
+    Decoder (\k -> return (ConsumeMapLenOrIndef (\n# ->
                      if I# n# >= 0
                        then k (Just (I# n#))
-                       else k Nothing))
+                       else k Nothing)))
 {-# INLINE decodeMapLenOrIndef #-}
 
 -- | Attempt to decode a @Break@ token, and if that was
@@ -506,8 +514,8 @@ decodeMapLenOrIndef =
 -- other type, return @'False'@.
 --
 -- @since 0.2.0.0
-decodeBreakOr :: Decoder Bool
-decodeBreakOr = Decoder (\k -> ConsumeBreakOr (\b -> k b))
+decodeBreakOr :: Decoder s Bool
+decodeBreakOr = Decoder (\k -> return (ConsumeBreakOr (\b -> k b)))
 {-# INLINE decodeBreakOr #-}
 
 --------------------------------------------------------------
@@ -517,16 +525,16 @@ decodeBreakOr = Decoder (\k -> ConsumeBreakOr (\b -> k b))
 -- @'TokenType'@ specifying what it is.
 --
 -- @since 0.2.0.0
-peekTokenType :: Decoder TokenType
-peekTokenType = Decoder (\k -> PeekTokenType (\tk -> k tk))
+peekTokenType :: Decoder s TokenType
+peekTokenType = Decoder (\k -> return (PeekTokenType (\tk -> k tk)))
 {-# INLINE peekTokenType #-}
 
 -- | Peek and return the length of the current buffer that we're
 -- running our decoder on.
 --
 -- @since 0.2.0.0
-peekAvailable :: Decoder Int
-peekAvailable = Decoder (\k -> PeekAvailable (\len# -> k (I# len#)))
+peekAvailable :: Decoder s Int
+peekAvailable = Decoder (\k -> return (PeekAvailable (\len# -> k (I# len#))))
 {-# INLINE peekAvailable #-}
 
 {-
@@ -550,8 +558,8 @@ ignoreTrailingTerms = IgnoreTerms done
 decodeSequenceLenIndef :: (r -> a -> r)
                        -> r
                        -> (r -> r')
-                       -> Decoder a
-                       -> Decoder r'
+                       -> Decoder s a
+                       -> Decoder s r'
 decodeSequenceLenIndef f z g get =
     go z
   where
@@ -568,8 +576,8 @@ decodeSequenceLenN :: (r -> a -> r)
                    -> r
                    -> (r -> r')
                    -> Int
-                   -> Decoder a
-                   -> Decoder r'
+                   -> Decoder s a
+                   -> Decoder s r'
 decodeSequenceLenN f z g c get =
     go z c
   where

--- a/Data/Binary/Serialise/CBOR/Decoding.hs
+++ b/Data/Binary/Serialise/CBOR/Decoding.hs
@@ -85,15 +85,9 @@ import           GHC.Int
 import           Data.Text (Text)
 import           Data.ByteString (ByteString)
 import           Control.Applicative
+import           Control.Monad.ST
 
 import           Prelude hiding (decodeFloat)
-
-#if defined(USE_ST)
-import Control.Monad.ST
-#else
-import Control.Monad.Identity (Identity(..))
-type ST s a = Identity a
-#endif
 
 
 -- | A continuation-based decoder, used for decoding values that were

--- a/Data/Binary/Serialise/CBOR/FlatTerm.hs
+++ b/Data/Binary/Serialise/CBOR/FlatTerm.hs
@@ -57,16 +57,8 @@ import           GHC.Float (Float(F#), Double(D#), float2Double)
 import           Data.Word
 import           Data.Text (Text)
 import           Data.ByteString (ByteString)
+import           Control.Monad.ST
 
-
-#if defined(USE_ST)
-import Control.Monad.ST
-#else
-import Control.Monad.Identity (Identity(..))
-type ST s a = Identity a
-runST :: (forall s. ST s a) -> a
-runST = runIdentity
-#endif
 
 --------------------------------------------------------------------------------
 

--- a/Data/Binary/Serialise/CBOR/FlatTerm.hs
+++ b/Data/Binary/Serialise/CBOR/FlatTerm.hs
@@ -147,154 +147,154 @@ fromFlatTerm :: (forall s. Decoder s a)
              -> FlatTerm        -- ^ The serialised @'FlatTerm'@.
              -> Either String a -- ^ The deserialised value, or an error.
 fromFlatTerm decoder ft =
-    runST (getDecodeAction decoder >>= flip go ft)
+    runST (getDecodeAction decoder >>= go ft)
   where
-    go :: DecodeAction s a -> FlatTerm -> ST s (Either String a)
-    go (ConsumeWord k)    (TkInt     n : ts)
-        | n >= 0                             = k (unW# (fromIntegral n)) >>= flip go ts
-    go (ConsumeWord k)    (TkInteger n : ts)
-        | n >= 0                             = k (unW# (fromIntegral n)) >>= flip go ts
-    go (ConsumeWord8 k)   (TkInt     n : ts)
-        | n >= 0 && n <= maxWord8            = k (unW# (fromIntegral n)) >>= flip go ts
-    go (ConsumeWord8 k)   (TkInteger n : ts)
-        | n >= 0 && n <= maxWord8            = k (unW# (fromIntegral n)) >>= flip go ts
-    go (ConsumeWord16 k)  (TkInt     n : ts)
-        | n >= 0 && n <= maxWord16           = k (unW# (fromIntegral n)) >>= flip go ts
-    go (ConsumeWord16 k)  (TkInteger n : ts)
-        | n >= 0 && n <= maxWord16           = k (unW# (fromIntegral n)) >>= flip go ts
-    go (ConsumeWord32 k)  (TkInt     n : ts)
+    go :: FlatTerm -> DecodeAction s a -> ST s (Either String a)
+    go (TkInt     n : ts) (ConsumeWord k)
+        | n >= 0                             = k (unW# (fromIntegral n)) >>= go ts
+    go (TkInteger n : ts) (ConsumeWord k)
+        | n >= 0                             = k (unW# (fromIntegral n)) >>= go ts
+    go (TkInt     n : ts) (ConsumeWord8 k)
+        | n >= 0 && n <= maxWord8            = k (unW# (fromIntegral n)) >>= go ts
+    go (TkInteger n : ts) (ConsumeWord8 k)
+        | n >= 0 && n <= maxWord8            = k (unW# (fromIntegral n)) >>= go ts
+    go (TkInt     n : ts) (ConsumeWord16 k)
+        | n >= 0 && n <= maxWord16           = k (unW# (fromIntegral n)) >>= go ts
+    go (TkInteger n : ts) (ConsumeWord16 k)
+        | n >= 0 && n <= maxWord16           = k (unW# (fromIntegral n)) >>= go ts
+    go (TkInt     n : ts) (ConsumeWord32 k)
         -- NOTE: we have to be very careful about this branch
         -- on 32 bit machines, because maxBound :: Int < maxBound :: Word32
-        | intIsValidWord32 n                 = k (unW# (fromIntegral n)) >>= flip go ts
-    go (ConsumeWord32 k)  (TkInteger n : ts)
-        | n >= 0 && n <= maxWord32           = k (unW# (fromIntegral n)) >>= flip go ts
-    go (ConsumeNegWord k) (TkInt     n : ts)
-        | n <  0                             = k (unW# (fromIntegral (-1-n))) >>= flip go ts
-    go (ConsumeNegWord k) (TkInteger n : ts)
-        | n <  0                             = k (unW# (fromIntegral (-1-n))) >>= flip go ts
-    go (ConsumeInt k)     (TkInt     n : ts) = k (unI# n) >>= flip go ts
-    go (ConsumeInt k)     (TkInteger n : ts)
-        | n <= maxInt                        = k (unI# (fromIntegral n)) >>= flip go ts
-    go (ConsumeInt8 k)    (TkInt     n : ts)
-        | n >= minInt8 && n <= maxInt8       = k (unI# n) >>= flip go ts
-    go (ConsumeInt8 k)    (TkInteger n : ts)
-        | n >= minInt8 && n <= maxInt8       = k (unI# (fromIntegral n)) >>= flip go ts
-    go (ConsumeInt16 k)   (TkInt     n : ts)
-        | n >= minInt16 && n <= maxInt16     = k (unI# n) >>= flip go ts
-    go (ConsumeInt16 k)    (TkInteger n : ts)
-        | n >= minInt16 && n <= maxInt16     = k (unI# (fromIntegral n)) >>= flip go ts
-    go (ConsumeInt32 k)    (TkInt     n : ts)
-        | n >= minInt32 && n <= maxInt32     = k (unI# n) >>= flip go ts
-    go (ConsumeInt32 k)    (TkInteger n : ts)
-        | n >= minInt32 && n <= maxInt32     = k (unI# (fromIntegral n)) >>= flip go ts
-    go (ConsumeInteger k) (TkInt     n : ts) = k (fromIntegral n) >>= flip go ts
-    go (ConsumeInteger k) (TkInteger n : ts) = k n >>= flip go ts
-    go (ConsumeListLen k) (TkListLen n : ts)
-        | n <= maxInt                        = k (unI# (fromIntegral n)) >>= flip go ts
-    go (ConsumeMapLen  k) (TkMapLen  n : ts)
-        | n <= maxInt                        = k (unI# (fromIntegral n)) >>= flip go ts
-    go (ConsumeTag     k) (TkTag     n : ts)
-        | n <= maxWord                       = k (unW# (fromIntegral n)) >>= flip go ts
+        | intIsValidWord32 n                 = k (unW# (fromIntegral n)) >>= go ts
+    go (TkInteger n : ts) (ConsumeWord32 k)
+        | n >= 0 && n <= maxWord32           = k (unW# (fromIntegral n)) >>= go ts
+    go (TkInt     n : ts) (ConsumeNegWord k)
+        | n <  0                             = k (unW# (fromIntegral (-1-n))) >>= go ts
+    go (TkInteger n : ts) (ConsumeNegWord k)
+        | n <  0                             = k (unW# (fromIntegral (-1-n))) >>= go ts
+    go (TkInt     n : ts) (ConsumeInt k)     = k (unI# n) >>= go ts
+    go (TkInteger n : ts) (ConsumeInt k)
+        | n <= maxInt                        = k (unI# (fromIntegral n)) >>= go ts
+    go (TkInt     n : ts) (ConsumeInt8 k)
+        | n >= minInt8 && n <= maxInt8       = k (unI# n) >>= go ts
+    go (TkInteger n : ts) (ConsumeInt8 k)
+        | n >= minInt8 && n <= maxInt8       = k (unI# (fromIntegral n)) >>= go ts
+    go (TkInt     n : ts) (ConsumeInt16 k)
+        | n >= minInt16 && n <= maxInt16     = k (unI# n) >>= go ts
+    go (TkInteger n : ts) (ConsumeInt16 k)
+        | n >= minInt16 && n <= maxInt16     = k (unI# (fromIntegral n)) >>= go ts
+    go (TkInt     n : ts) (ConsumeInt32 k)
+        | n >= minInt32 && n <= maxInt32     = k (unI# n) >>= go ts
+    go (TkInteger n : ts) (ConsumeInt32 k)
+        | n >= minInt32 && n <= maxInt32     = k (unI# (fromIntegral n)) >>= go ts
+    go (TkInt     n : ts) (ConsumeInteger k) = k (fromIntegral n) >>= go ts
+    go (TkInteger n : ts) (ConsumeInteger k) = k n >>= go ts
+    go (TkListLen n : ts) (ConsumeListLen k)
+        | n <= maxInt                        = k (unI# (fromIntegral n)) >>= go ts
+    go (TkMapLen  n : ts) (ConsumeMapLen  k)
+        | n <= maxInt                        = k (unI# (fromIntegral n)) >>= go ts
+    go (TkTag     n : ts) (ConsumeTag     k)
+        | n <= maxWord                       = k (unW# (fromIntegral n)) >>= go ts
 
 #if defined(ARCH_32bit)
     -- 64bit variants for 32bit machines
-    go (ConsumeWord64    k) (TkInt       n : ts)
-      | n >= 0                                   = k (unW64# (fromIntegral n)) >>= flip go ts
-    go (ConsumeWord64    k) (TkInteger   n : ts)
-      | n >= 0                                   = k (unW64# (fromIntegral n)) >>= flip go ts
-    go (ConsumeNegWord64 k) (TkInt       n : ts)
-      | n < 0                                    = k (unW64# (fromIntegral (-1-n))) >>= flip go ts
-    go (ConsumeNegWord64 k) (TkInteger   n : ts)
-      | n < 0                                    = k (unW64# (fromIntegral (-1-n))) >>= flip go ts
+    go (TkInt       n : ts) (ConsumeWord64    k)
+      | n >= 0                                   = k (unW64# (fromIntegral n)) >>= go ts
+    go (TkInteger   n : ts) (ConsumeWord64    k)
+      | n >= 0                                   = k (unW64# (fromIntegral n)) >>= go ts
+    go (TkInt       n : ts) (ConsumeNegWord64 k)
+      | n < 0                                    = k (unW64# (fromIntegral (-1-n))) >>= go ts
+    go (TkInteger   n : ts) (ConsumeNegWord64 k)
+      | n < 0                                    = k (unW64# (fromIntegral (-1-n))) >>= go ts
 
-    go (ConsumeInt64     k) (TkInt       n : ts) = k (unI64# (fromIntegral n)) >>= flip go ts
-    go (ConsumeInt64     k) (TkInteger   n : ts) = k (unI64# (fromIntegral n)) >>= flip go ts
+    go (TkInt       n : ts) (ConsumeInt64     k) = k (unI64# (fromIntegral n)) >>= go ts
+    go (TkInteger   n : ts) (ConsumeInt64     k) = k (unI64# (fromIntegral n)) >>= go ts
 
-    go (ConsumeTag64     k) (TkTag       n : ts) = k (unW64# n) >>= flip go ts
+    go (TkTag       n : ts) (ConsumeTag64     k) = k (unW64# n) >>= go ts
 
     -- TODO FIXME (aseipp/dcoutts): are these going to be utilized?
     -- see fallthrough case below if/when fixed.
-    go (ConsumeListLen64 _) ts                   = unexpected "decodeListLen64" ts
-    go (ConsumeMapLen64  _) ts                   = unexpected "decodeMapLen64"  ts
+    go ts (ConsumeListLen64 _)                   = unexpected "decodeListLen64" ts
+    go ts (ConsumeMapLen64  _)                   = unexpected "decodeMapLen64"  ts
 #endif
 
-    go (ConsumeFloat  k) (TkFloat16 f : ts) = k (unF# f) >>= flip go ts
-    go (ConsumeFloat  k) (TkFloat32 f : ts) = k (unF# f) >>= flip go ts
-    go (ConsumeDouble k) (TkFloat16 f : ts) = k (unD# (float2Double f)) >>= flip go ts
-    go (ConsumeDouble k) (TkFloat32 f : ts) = k (unD# (float2Double f)) >>= flip go ts
-    go (ConsumeDouble k) (TkFloat64 f : ts) = k (unD# f) >>= flip go ts
-    go (ConsumeBytes  k) (TkBytes  bs : ts) = k bs >>= flip go ts
-    go (ConsumeString k) (TkString st : ts) = k st >>= flip go ts
-    go (ConsumeBool   k) (TkBool    b : ts) = k b >>= flip go ts
-    go (ConsumeSimple k) (TkSimple  n : ts) = k (unW8# n) >>= flip go ts
+    go (TkFloat16 f : ts) (ConsumeFloat  k) = k (unF# f) >>= go ts
+    go (TkFloat32 f : ts) (ConsumeFloat  k) = k (unF# f) >>= go ts
+    go (TkFloat16 f : ts) (ConsumeDouble k) = k (unD# (float2Double f)) >>= go ts
+    go (TkFloat32 f : ts) (ConsumeDouble k) = k (unD# (float2Double f)) >>= go ts
+    go (TkFloat64 f : ts) (ConsumeDouble k) = k (unD# f) >>= go ts
+    go (TkBytes  bs : ts) (ConsumeBytes  k) = k bs >>= go ts
+    go (TkString st : ts) (ConsumeString k) = k st >>= go ts
+    go (TkBool    b : ts) (ConsumeBool   k) = k b >>= go ts
+    go (TkSimple  n : ts) (ConsumeSimple k) = k (unW8# n) >>= go ts
 
-    go (ConsumeBytesIndef   da) (TkBytesBegin  : ts) = da >>= flip go ts
-    go (ConsumeStringIndef  da) (TkStringBegin : ts) = da >>= flip go ts
-    go (ConsumeListLenIndef da) (TkListBegin   : ts) = da >>= flip go ts
-    go (ConsumeMapLenIndef  da) (TkMapBegin    : ts) = da >>= flip go ts
-    go (ConsumeNull         da) (TkNull        : ts) = da >>= flip go ts
+    go (TkBytesBegin  : ts) (ConsumeBytesIndef   da) = da >>= go ts
+    go (TkStringBegin : ts) (ConsumeStringIndef  da) = da >>= go ts
+    go (TkListBegin   : ts) (ConsumeListLenIndef da) = da >>= go ts
+    go (TkMapBegin    : ts) (ConsumeMapLenIndef  da) = da >>= go ts
+    go (TkNull        : ts) (ConsumeNull         da) = da >>= go ts
 
-    go (ConsumeListLenOrIndef k) (TkListLen n : ts)
-        | n <= maxInt                               = k (unI# (fromIntegral n)) >>= flip go ts
-    go (ConsumeListLenOrIndef k) (TkListBegin : ts) = k (-1#) >>= flip go ts
-    go (ConsumeMapLenOrIndef  k) (TkMapLen  n : ts)
-        | n <= maxInt                               = k (unI# (fromIntegral n)) >>= flip go ts
-    go (ConsumeMapLenOrIndef  k) (TkMapBegin  : ts) = k (-1#) >>= flip go ts
-    go (ConsumeBreakOr        k) (TkBreak     : ts) = k True >>= flip go ts
-    go (ConsumeBreakOr        k) ts@(_        : _ ) = k False >>= flip go ts
+    go (TkListLen n : ts) (ConsumeListLenOrIndef k)
+        | n <= maxInt                               = k (unI# (fromIntegral n)) >>= go ts
+    go (TkListBegin : ts) (ConsumeListLenOrIndef k) = k (-1#) >>= go ts
+    go (TkMapLen  n : ts) (ConsumeMapLenOrIndef  k)
+        | n <= maxInt                               = k (unI# (fromIntegral n)) >>= go ts
+    go (TkMapBegin  : ts) (ConsumeMapLenOrIndef  k) = k (-1#) >>= go ts
+    go (TkBreak     : ts) (ConsumeBreakOr        k) = k True >>= go ts
+    go ts@(_        : _ ) (ConsumeBreakOr        k) = k False >>= go ts
 
-    go (PeekTokenType k) ts@(tk:_) = k (tokenTypeOf tk) >>= flip go ts
-    go (PeekTokenType _) ts        = unexpected "peekTokenType" ts
-    go (PeekAvailable k) ts        = k (unI# (length ts)) >>= flip go ts
+    go ts@(tk:_) (PeekTokenType k) = k (tokenTypeOf tk) >>= go ts
+    go ts        (PeekTokenType _) = unexpected "peekTokenType" ts
+    go ts        (PeekAvailable k) = k (unI# (length ts)) >>= go ts
 
-    go (Fail msg) _  = return $ Left msg
-    go (Done x)   [] = return $ Right x
-    go (Done _)   ts = return $ Left ("trailing tokens: " ++ show (take 5 ts))
+    go _  (Fail msg) = return $ Left msg
+    go [] (Done x)   = return $ Right x
+    go ts (Done _)   = return $ Left ("trailing tokens: " ++ show (take 5 ts))
 
     ----------------------------------------------------------------------------
     -- Fallthrough cases: unhandled token/DecodeAction combinations
 
-    go (ConsumeWord    _) ts = unexpected "decodeWord"    ts
-    go (ConsumeWord8   _) ts = unexpected "decodeWord8"   ts
-    go (ConsumeWord16  _) ts = unexpected "decodeWord16"  ts
-    go (ConsumeWord32  _) ts = unexpected "decodeWord32"  ts
-    go (ConsumeNegWord _) ts = unexpected "decodeNegWord" ts
-    go (ConsumeInt     _) ts = unexpected "decodeInt"     ts
-    go (ConsumeInt8    _) ts = unexpected "decodeInt8"    ts
-    go (ConsumeInt16   _) ts = unexpected "decodeInt16"   ts
-    go (ConsumeInt32   _) ts = unexpected "decodeInt32"   ts
-    go (ConsumeInteger _) ts = unexpected "decodeInteger" ts
+    go ts (ConsumeWord    _) = unexpected "decodeWord"    ts
+    go ts (ConsumeWord8   _) = unexpected "decodeWord8"   ts
+    go ts (ConsumeWord16  _) = unexpected "decodeWord16"  ts
+    go ts (ConsumeWord32  _) = unexpected "decodeWord32"  ts
+    go ts (ConsumeNegWord _) = unexpected "decodeNegWord" ts
+    go ts (ConsumeInt     _) = unexpected "decodeInt"     ts
+    go ts (ConsumeInt8    _) = unexpected "decodeInt8"    ts
+    go ts (ConsumeInt16   _) = unexpected "decodeInt16"   ts
+    go ts (ConsumeInt32   _) = unexpected "decodeInt32"   ts
+    go ts (ConsumeInteger _) = unexpected "decodeInteger" ts
 
-    go (ConsumeListLen _) ts = unexpected "decodeListLen" ts
-    go (ConsumeMapLen  _) ts = unexpected "decodeMapLen"  ts
-    go (ConsumeTag     _) ts = unexpected "decodeTag"     ts
+    go ts (ConsumeListLen _) = unexpected "decodeListLen" ts
+    go ts (ConsumeMapLen  _) = unexpected "decodeMapLen"  ts
+    go ts (ConsumeTag     _) = unexpected "decodeTag"     ts
 
-    go (ConsumeFloat  _) ts = unexpected "decodeFloat"  ts
-    go (ConsumeDouble _) ts = unexpected "decodeDouble" ts
-    go (ConsumeBytes  _) ts = unexpected "decodeBytes"  ts
-    go (ConsumeString _) ts = unexpected "decodeString" ts
-    go (ConsumeBool   _) ts = unexpected "decodeBool"   ts
-    go (ConsumeSimple _) ts = unexpected "decodeSimple" ts
+    go ts (ConsumeFloat  _) = unexpected "decodeFloat"  ts
+    go ts (ConsumeDouble _) = unexpected "decodeDouble" ts
+    go ts (ConsumeBytes  _) = unexpected "decodeBytes"  ts
+    go ts (ConsumeString _) = unexpected "decodeString" ts
+    go ts (ConsumeBool   _) = unexpected "decodeBool"   ts
+    go ts (ConsumeSimple _) = unexpected "decodeSimple" ts
 
 #if defined(ARCH_32bit)
     -- 64bit variants for 32bit machines
-    go (ConsumeWord64    _) ts = unexpected "decodeWord64"    ts
-    go (ConsumeNegWord64 _) ts = unexpected "decodeNegWord64" ts
-    go (ConsumeInt64     _) ts = unexpected "decodeInt64"     ts
-    go (ConsumeTag64     _) ts = unexpected "decodeTag64"     ts
-  --go (ConsumeListLen64 _) ts = unexpected "decodeListLen64" ts
-  --go (ConsumeMapLen64  _) ts = unexpected "decodeMapLen64"  ts
+    go ts (ConsumeWord64    _) = unexpected "decodeWord64"    ts
+    go ts (ConsumeNegWord64 _) = unexpected "decodeNegWord64" ts
+    go ts (ConsumeInt64     _) = unexpected "decodeInt64"     ts
+    go ts (ConsumeTag64     _) = unexpected "decodeTag64"     ts
+  --go ts (ConsumeListLen64 _) = unexpected "decodeListLen64" ts
+  --go ts (ConsumeMapLen64  _) = unexpected "decodeMapLen64"  ts
 #endif
 
-    go (ConsumeBytesIndef   _) ts = unexpected "decodeBytesIndef"   ts
-    go (ConsumeStringIndef  _) ts = unexpected "decodeStringIndef"  ts
-    go (ConsumeListLenIndef _) ts = unexpected "decodeListLenIndef" ts
-    go (ConsumeMapLenIndef  _) ts = unexpected "decodeMapLenIndef"  ts
-    go (ConsumeNull         _) ts = unexpected "decodeNull"         ts
+    go ts (ConsumeBytesIndef   _) = unexpected "decodeBytesIndef"   ts
+    go ts (ConsumeStringIndef  _) = unexpected "decodeStringIndef"  ts
+    go ts (ConsumeListLenIndef _) = unexpected "decodeListLenIndef" ts
+    go ts (ConsumeMapLenIndef  _) = unexpected "decodeMapLenIndef"  ts
+    go ts (ConsumeNull         _) = unexpected "decodeNull"         ts
 
-    go (ConsumeListLenOrIndef _) ts = unexpected "decodeListLenOrIndef" ts
-    go (ConsumeMapLenOrIndef  _) ts = unexpected "decodeMapLenOrIndef"  ts
-    go (ConsumeBreakOr        _) ts = unexpected "decodeBreakOr"        ts
+    go ts (ConsumeListLenOrIndef _) = unexpected "decodeListLenOrIndef" ts
+    go ts (ConsumeMapLenOrIndef  _) = unexpected "decodeMapLenOrIndef"  ts
+    go ts (ConsumeBreakOr        _) = unexpected "decodeBreakOr"        ts
 
     unexpected name []      = return $ Left $ name ++ ": unexpected end of input"
     unexpected name (tok:_) = return $ Left $ name ++ ": unexpected token " ++ show tok

--- a/Data/Binary/Serialise/CBOR/Read.hs
+++ b/Data/Binary/Serialise/CBOR/Read.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 
+-- Bump up from the default 1.5, otherwise our decoder fast path is no good.
+-- We went over the threshold when we switched to using ST.
+{-# OPTIONS_GHC -funfolding-keeness-factor=2.0 #-}
+
 -- |
 -- Module      : Data.Binary.Serialise.CBOR.Read
 -- Copyright   : (c) Duncan Coutts 2015

--- a/Data/Binary/Serialise/CBOR/Read.hs
+++ b/Data/Binary/Serialise/CBOR/Read.hs
@@ -114,7 +114,7 @@ data IDecode s a
 -- or an error.
 --
 -- @since 0.2.0.0
-deserialiseFromBytes :: Decoder a
+deserialiseFromBytes :: (forall s. Decoder s a)
                      -> LBS.ByteString
                      -> Either DeserialiseFailure a
 deserialiseFromBytes d lbs =
@@ -136,9 +136,9 @@ runIDecode d lbs =
 -- representing the result of the incremental decode.
 --
 -- @since 0.2.0.0
-deserialiseIncremental :: Decoder a -> ST s (IDecode s a)
-deserialiseIncremental decoder =
-    let da = getDecodeAction decoder in
+deserialiseIncremental :: Decoder s a -> ST s (IDecode s a)
+deserialiseIncremental decoder = do
+    da <- getDecodeAction decoder
     runIncrementalDecoder (runDecodeAction da)
 
 ----------------------------------------------
@@ -188,11 +188,11 @@ lift action = IncrementalDecoder (\k -> action >>= k)
 --
 
 -- The top level entry point
-runDecodeAction :: DecodeAction a -> IncrementalDecoder s (ByteString, ByteOffset, a)
+runDecodeAction :: DecodeAction s a
+                -> IncrementalDecoder s (ByteString, ByteOffset, a)
 runDecodeAction (D.Fail msg)        = decodeFail BS.empty 0 msg
 runDecodeAction (D.Done x)          = return (BS.empty, 0, x)
-runDecodeAction (D.PeekAvailable k) = runDecodeAction (k 0#)
-
+runDecodeAction (D.PeekAvailable k) = lift (k 0#) >>= runDecodeAction
 runDecodeAction da = do
     mbs <- needChunk
     case mbs of
@@ -216,9 +216,9 @@ runDecodeAction da = do
 --
 data SlowPath s a
    = FastDone               {-# UNPACK #-} !ByteString a
-   | SlowConsumeTokenString {-# UNPACK #-} !ByteString (T.Text     -> DecodeAction a) {-# UNPACK #-} !Int
-   | SlowConsumeTokenBytes  {-# UNPACK #-} !ByteString (ByteString -> DecodeAction a) {-# UNPACK #-} !Int
-   | SlowDecodeAction       {-# UNPACK #-} !ByteString (DecodeAction a)
+   | SlowConsumeTokenString {-# UNPACK #-} !ByteString (T.Text     -> ST s (DecodeAction s a)) {-# UNPACK #-} !Int
+   | SlowConsumeTokenBytes  {-# UNPACK #-} !ByteString (ByteString -> ST s (DecodeAction s a)) {-# UNPACK #-} !Int
+   | SlowDecodeAction       {-# UNPACK #-} !ByteString (DecodeAction s a)
    | SlowFail               {-# UNPACK #-} !ByteString String
 
 
@@ -230,21 +230,21 @@ data SlowPath s a
 -- chunk, in particular we just check if there's enough input buffer space
 -- left for the largest possible fixed-size token (8+1 bytes).
 --
-go_fast :: DecodeAction a -> ByteString -> ST s (SlowPath s a)
+go_fast :: DecodeAction s a -> ByteString -> ST s (SlowPath s a)
 
 go_fast da !bs | BS.length bs < 9 = go_fast_end da bs
 
 go_fast da@(ConsumeWord k) !bs =
     case tryConsumeWord (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (W# w#) -> go_fast (k w#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (W# w#) -> k w# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeWord8 k) !bs =
     case tryConsumeWord (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
       DecodedToken sz (W# w#) ->
         case gtWord# w# 0xff## of
-          0#                  -> go_fast (k w#) (BS.unsafeDrop sz bs)
+          0#                  -> k w#  >>= flip go_fast (BS.unsafeDrop sz bs)
           _                   -> go_fast_end da bs
 
 go_fast da@(ConsumeWord16 k) !bs =
@@ -252,7 +252,7 @@ go_fast da@(ConsumeWord16 k) !bs =
       DecodeFailure           -> go_fast_end da bs
       DecodedToken sz (W# w#) ->
         case gtWord# w# 0xffff## of
-          0#                  -> go_fast (k w#) (BS.unsafeDrop sz bs)
+          0#                  -> k w#  >>= flip go_fast (BS.unsafeDrop sz bs)
           _                   -> go_fast_end da bs
 
 go_fast da@(ConsumeWord32 k) !bs =
@@ -260,29 +260,29 @@ go_fast da@(ConsumeWord32 k) !bs =
       DecodeFailure           -> go_fast_end da bs
       DecodedToken sz (W# w#) ->
 #if defined(ARCH_32bit)
-                                 go_fast (k w#) (BS.unsafeDrop sz bs)
+                                 k w# >>= flip go_fast (BS.unsafeDrop sz bs)
 #else
         case gtWord# w# 0xffffffff## of
-          0#                  -> go_fast (k w#) (BS.unsafeDrop sz bs)
+          0#                  -> k w# >>= flip go_fast (BS.unsafeDrop sz bs)
           _                   -> go_fast_end da bs
 #endif
 
 go_fast da@(ConsumeNegWord k) !bs =
     case tryConsumeNegWord (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (W# w#) -> go_fast (k w#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (W# w#) -> k w# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeInt k) !bs =
     case tryConsumeInt (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (I# n#) -> go_fast (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeInt8 k) !bs =
     case tryConsumeInt (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
       DecodedToken sz (I# n#) ->
         case (n# ># 0x7f#) `orI#` (n# <# -0x80#) of
-          0#                  -> go_fast (k n#) (BS.unsafeDrop sz bs)
+          0#                  -> k n# >>= flip go_fast (BS.unsafeDrop sz bs)
           _                   -> go_fast_end da bs
 
 go_fast da@(ConsumeInt16 k) !bs =
@@ -290,7 +290,7 @@ go_fast da@(ConsumeInt16 k) !bs =
       DecodeFailure           -> go_fast_end da bs
       DecodedToken sz (I# n#) ->
         case (n# ># 0x7fff#) `orI#` (n# <# -0x8000#) of
-          0#                  -> go_fast (k n#) (BS.unsafeDrop sz bs)
+          0#                  -> k n# >>= flip go_fast (BS.unsafeDrop sz bs)
           _                   -> go_fast_end da bs
 
 go_fast da@(ConsumeInt32 k) !bs =
@@ -298,143 +298,143 @@ go_fast da@(ConsumeInt32 k) !bs =
       DecodeFailure           -> go_fast_end da bs
       DecodedToken sz (I# n#) ->
 #if defined(ARCH_32bit)
-                                 go_fast (k n#) (BS.unsafeDrop sz bs)
+                                 k n# >>= flip go_fast (BS.unsafeDrop sz bs)
 #else
         case (n# ># 0x7fffffff#) `orI#` (n# <# -0x80000000#) of
-          0#                  -> go_fast (k n#) (BS.unsafeDrop sz bs)
+          0#                  -> k n# >>= flip go_fast (BS.unsafeDrop sz bs)
           _                   -> go_fast_end da bs
 #endif
 
 go_fast da@(ConsumeListLen k) !bs =
     case tryConsumeListLen (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (I# n#) -> go_fast (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeMapLen k) !bs =
     case tryConsumeMapLen (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (I# n#) -> go_fast (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeTag k) !bs =
     case tryConsumeTag (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (W# w#) -> go_fast (k w#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (W# w#) -> k w# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 #if defined(ARCH_32bit)
 go_fast da@(ConsumeWord64 k) !bs =
   case tryConsumeWord64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> go_fast_end da bs
-    DecodedToken sz (W64# w#) -> go_fast (k w#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (W64# w#) -> k w# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeNegWord64 k) !bs =
   case tryConsumeNegWord64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> go_fast_end da bs
-    DecodedToken sz (W64# w#) -> go_fast (k w#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (W64# w#) -> k w# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeInt64 k) !bs =
   case tryConsumeInt64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> go_fast_end da bs
-    DecodedToken sz (I64# i#) -> go_fast (k i#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (I64# i#) -> k i# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeListLen64 k) !bs =
   case tryConsumeListLen64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> go_fast_end da bs
-    DecodedToken sz (I64# i#) -> go_fast (k i#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (I64# i#) -> k i# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeMapLen64 k) !bs =
   case tryConsumeMapLen64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> go_fast_end da bs
-    DecodedToken sz (I64# i#) -> go_fast (k i#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (I64# i#) -> k i# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeTag64 k) !bs =
   case tryConsumeTag64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> go_fast_end da bs
-    DecodedToken sz (W64# w#) -> go_fast (k w#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (W64# w#) -> k w# >>= flip go_fast (BS.unsafeDrop sz bs)
 #endif
 
 go_fast da@(ConsumeInteger k) !bs =
     case tryConsumeInteger (BS.unsafeHead bs) bs of
-      DecodedToken sz (BigIntToken n) -> go_fast (k n) (BS.unsafeDrop sz bs)
+      DecodedToken sz (BigIntToken n) -> k n >>= flip go_fast (BS.unsafeDrop sz bs)
       _                               -> go_fast_end da bs
 
 go_fast da@(ConsumeFloat k) !bs =
     case tryConsumeFloat (BS.unsafeHead bs) bs of
       DecodeFailure     -> go_fast_end da bs
-      DecodedToken sz (F# f#) -> go_fast (k f#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (F# f#) -> k f# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeDouble k) !bs =
     case tryConsumeDouble (BS.unsafeHead bs) bs of
       DecodeFailure     -> go_fast_end da bs
-      DecodedToken sz (D# f#) -> go_fast (k f#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (D# f#) -> k f# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeBytes k) !bs =
     case tryConsumeBytes (BS.unsafeHead bs) bs of
       DecodeFailure                 -> go_fast_end da bs
-      DecodedToken sz (Fits bstr)   -> go_fast (k bstr) (BS.unsafeDrop sz bs)
+      DecodedToken sz (Fits bstr)   -> k bstr >>= flip go_fast (BS.unsafeDrop sz bs)
       DecodedToken sz (TooLong len) -> return $! SlowConsumeTokenBytes (BS.unsafeDrop sz bs) k len
 
 go_fast da@(ConsumeString k) !bs =
     case tryConsumeString (BS.unsafeHead bs) bs of
       DecodeFailure                 -> go_fast_end da bs
-      DecodedToken sz (Fits str)    -> go_fast (k str) (BS.unsafeDrop sz bs)
+      DecodedToken sz (Fits str)    -> k str >>= flip go_fast (BS.unsafeDrop sz bs)
       DecodedToken sz (TooLong len) -> return $! SlowConsumeTokenString (BS.unsafeDrop sz bs) k len
 
 go_fast da@(ConsumeBool k) !bs =
     case tryConsumeBool (BS.unsafeHead bs) of
       DecodeFailure     -> go_fast_end da bs
-      DecodedToken sz b -> go_fast (k b) (BS.unsafeDrop sz bs)
+      DecodedToken sz b -> k b >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeSimple k) !bs =
     case tryConsumeSimple (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (W# w#) -> go_fast (k w#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (W# w#) -> k w# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeBytesIndef k) !bs =
     case tryConsumeBytesIndef (BS.unsafeHead bs) of
       DecodeFailure     -> go_fast_end da bs
-      DecodedToken sz _ -> go_fast k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeStringIndef k) !bs =
     case tryConsumeStringIndef (BS.unsafeHead bs) of
       DecodeFailure     -> go_fast_end da bs
-      DecodedToken sz _ -> go_fast k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeListLenIndef k) !bs =
     case tryConsumeListLenIndef (BS.unsafeHead bs) of
       DecodeFailure     -> go_fast_end da bs
-      DecodedToken sz _ -> go_fast k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeMapLenIndef k) !bs =
     case tryConsumeMapLenIndef (BS.unsafeHead bs) of
       DecodeFailure     -> go_fast_end da bs
-      DecodedToken sz _ -> go_fast k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeNull k) !bs =
     case tryConsumeNull (BS.unsafeHead bs) of
       DecodeFailure     -> go_fast_end da bs
-      DecodedToken sz _ -> go_fast k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeListLenOrIndef k) !bs =
     case tryConsumeListLenOrIndef (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (I# n#) -> go_fast (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast da@(ConsumeMapLenOrIndef k) !bs =
     case tryConsumeMapLenOrIndef (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end da bs
-      DecodedToken sz (I# n#) -> go_fast (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast (ConsumeBreakOr k) !bs =
     case tryConsumeBreakOr (BS.unsafeHead bs) of
-      DecodeFailure     -> go_fast (k False) bs
-      DecodedToken sz _ -> go_fast (k True) (BS.unsafeDrop sz bs)
+      DecodeFailure     -> k False >>= flip go_fast bs
+      DecodedToken sz _ -> k True >>= flip go_fast (BS.unsafeDrop sz bs)
 
 go_fast (PeekTokenType k) !bs =
     let !hdr  = BS.unsafeHead bs
         !tkty = decodeTokenTypeTable `A.unsafeAt` fromIntegral hdr
-    in go_fast (k tkty) bs
+    in k tkty >>= flip go_fast bs
 
-go_fast (PeekAvailable k) !bs = go_fast (k (case BS.length bs of I# len# -> len#)) bs
+go_fast (PeekAvailable k) !bs = k (case BS.length bs of I# len# -> len#) >>= flip go_fast bs
 
 go_fast da@D.Fail{} !bs = go_fast_end da bs
 go_fast da@D.Done{} !bs = go_fast_end da bs
@@ -447,26 +447,26 @@ go_fast da@D.Done{} !bs = go_fast_end da bs
 -- or failed) then there's one remaining token that spans the end of the
 -- input chunk (the slow path fixup code relies on this guarantee).
 --
-go_fast_end :: DecodeAction a -> ByteString -> ST s (SlowPath s a)
+go_fast_end :: DecodeAction s a -> ByteString -> ST s (SlowPath s a)
 
 -- these three cases don't need any input
 
 go_fast_end (D.Fail msg)      !bs = return $! SlowFail bs msg
 go_fast_end (D.Done x)        !bs = return $! FastDone bs x
-go_fast_end (PeekAvailable k) !bs = go_fast_end (k (case BS.length bs of I# len# -> len#)) bs
+go_fast_end (PeekAvailable k) !bs = k (case BS.length bs of I# len# -> len#) >>= flip go_fast_end bs
 
 -- the next two cases only need the 1 byte token header
 go_fast_end da !bs | BS.null bs = return $! SlowDecodeAction bs da
 
 go_fast_end (ConsumeBreakOr k) !bs =
     case tryConsumeBreakOr (BS.unsafeHead bs) of
-      DecodeFailure     -> go_fast_end (k False) bs
-      DecodedToken sz _ -> go_fast_end (k True) (BS.unsafeDrop sz bs)
+      DecodeFailure     -> k False >>= flip go_fast_end bs
+      DecodedToken sz _ -> k True  >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (PeekTokenType k) !bs =
     let !hdr  = BS.unsafeHead bs
         !tkty = decodeTokenTypeTable `A.unsafeAt` fromIntegral hdr
-    in go_fast_end (k tkty) bs
+    in k tkty >>= flip go_fast_end bs
 
 -- all the remaining cases have to decode the current token
 
@@ -478,14 +478,14 @@ go_fast_end da !bs
 go_fast_end (ConsumeWord k) !bs =
     case tryConsumeWord (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected word"
-      DecodedToken sz (W# w#) -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (W# w#) -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeWord8 k) !bs =
     case tryConsumeWord (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected word8"
       DecodedToken sz (W# w#) ->
         case gtWord# w# 0xff## of
-          0#                  -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+          0#                  -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
           _                   -> return $! SlowFail bs "expected word8"
 
 go_fast_end (ConsumeWord16 k) !bs =
@@ -493,7 +493,7 @@ go_fast_end (ConsumeWord16 k) !bs =
       DecodeFailure           -> return $! SlowFail bs "expected word16"
       DecodedToken sz (W# w#) ->
         case gtWord# w# 0xffff## of
-          0#                  -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+          0#                  -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
           _                   -> return $! SlowFail bs "expected word16"
 
 go_fast_end (ConsumeWord32 k) !bs =
@@ -501,29 +501,29 @@ go_fast_end (ConsumeWord32 k) !bs =
       DecodeFailure           -> return $! SlowFail bs "expected word32"
       DecodedToken sz (W# w#) ->
 #if defined(ARCH_32bit)
-                                 go_fast_end (k w#) (BS.unsafeDrop sz bs)
+                                 k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 #else
         case gtWord# w# 0xffffffff## of
-          0#                  -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+          0#                  -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
           _                   -> return $! SlowFail bs "expected word32"
 #endif
 
 go_fast_end (ConsumeNegWord k) !bs =
     case tryConsumeNegWord (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected negative int"
-      DecodedToken sz (W# w#) -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (W# w#) -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeInt k) !bs =
     case tryConsumeInt (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected int"
-      DecodedToken sz (I# n#) -> go_fast_end (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeInt8 k) !bs =
     case tryConsumeInt (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected int8"
       DecodedToken sz (I# n#) ->
         case (n# ># 0x7f#) `orI#` (n# <# -0x80#) of
-          0#                  -> go_fast_end (k n#) (BS.unsafeDrop sz bs)
+          0#                  -> k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
           _                   -> return $! SlowFail bs "expected int8"
 
 go_fast_end (ConsumeInt16 k) !bs =
@@ -531,7 +531,7 @@ go_fast_end (ConsumeInt16 k) !bs =
       DecodeFailure           -> return $! SlowFail bs "expected int16"
       DecodedToken sz (I# n#) ->
         case (n# ># 0x7fff#) `orI#` (n# <# -0x8000#) of
-          0#                  -> go_fast_end (k n#) (BS.unsafeDrop sz bs)
+          0#                  -> k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
           _                   -> return $! SlowFail bs "expected int16"
 
 go_fast_end (ConsumeInt32 k) !bs =
@@ -539,64 +539,64 @@ go_fast_end (ConsumeInt32 k) !bs =
       DecodeFailure           -> return $! SlowFail bs "expected int32"
       DecodedToken sz (I# n#) ->
 #if defined(ARCH_32bit)
-                                 go_fast_end (k n#) (BS.unsafeDrop sz bs)
+                                 k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 #else
         case (n# ># 0x7fffffff#) `orI#` (n# <# -0x80000000#) of
-          0#                  -> go_fast_end (k n#) (BS.unsafeDrop sz bs)
+          0#                  -> k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
           _                   -> return $! SlowFail bs "expected int32"
 #endif
 
 go_fast_end (ConsumeListLen k) !bs =
     case tryConsumeListLen (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected list len"
-      DecodedToken sz (I# n#) -> go_fast_end (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeMapLen k) !bs =
     case tryConsumeMapLen (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected map len"
-      DecodedToken sz (I# n#) -> go_fast_end (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeTag k) !bs =
     case tryConsumeTag (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected tag"
-      DecodedToken sz (W# w#) -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (W# w#) -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 #if defined(ARCH_32bit)
 go_fast_end (ConsumeWord64 k) !bs =
   case tryConsumeWord64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> return $! SlowFail bs "expected word64"
-    DecodedToken sz (W64# w#) -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (W64# w#) -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeNegWord64 k) !bs =
   case tryConsumeNegWord64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> return $! SlowFail bs "expected negative word64"
-    DecodedToken sz (W64# w#) -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (W64# w#) -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeInt64 k) !bs =
   case tryConsumeInt64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> return $! SlowFail bs "expected int64"
-    DecodedToken sz (I64# i#) -> go_fast_end (k i#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (I64# i#) -> k i# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeListLen64 k) !bs =
   case tryConsumeListLen64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> return $! SlowFail bs "expected list len 64"
-    DecodedToken sz (I64# i#) -> go_fast_end (k i#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (I64# i#) -> k i# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeMapLen64 k) !bs =
   case tryConsumeMapLen64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> return $! SlowFail bs "expected map len 64"
-    DecodedToken sz (I64# i#) -> go_fast_end (k i#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (I64# i#) -> k i# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeTag64 k) !bs =
   case tryConsumeTag64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> return $! SlowFail bs "expected tag64"
-    DecodedToken sz (W64# w#) -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+    DecodedToken sz (W64# w#) -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 #endif
 
 go_fast_end (ConsumeInteger k) !bs =
     case tryConsumeInteger (BS.unsafeHead bs) bs of
       DecodeFailure                         -> return $! SlowFail bs "expected integer"
-      DecodedToken sz (BigIntToken n)       -> go_fast_end (k n) (BS.unsafeDrop sz bs)
+      DecodedToken sz (BigIntToken n)       -> k n >>= flip go_fast_end (BS.unsafeDrop sz bs)
       DecodedToken sz (BigUIntNeedBody len) -> return $! SlowConsumeTokenBytes (BS.unsafeDrop sz bs) (adjustContBigUIntNeedBody k) len
       DecodedToken sz (BigNIntNeedBody len) -> return $! SlowConsumeTokenBytes (BS.unsafeDrop sz bs) (adjustContBigNIntNeedBody k) len
       DecodedToken sz  BigUIntNeedHeader    -> return $! SlowDecodeAction      (BS.unsafeDrop sz bs) (adjustContBigUIntNeedHeader k)
@@ -605,69 +605,69 @@ go_fast_end (ConsumeInteger k) !bs =
 go_fast_end (ConsumeFloat k) !bs =
     case tryConsumeFloat (BS.unsafeHead bs) bs of
       DecodeFailure     -> return $! SlowFail bs "expected float"
-      DecodedToken sz (F# f#) -> go_fast_end (k f#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (F# f#) -> k f# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeDouble k) !bs =
     case tryConsumeDouble (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected double"
-      DecodedToken sz (D# f#) -> go_fast_end (k f#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (D# f#) -> k f# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeBytes k) !bs =
     case tryConsumeBytes (BS.unsafeHead bs) bs of
       DecodeFailure                 -> return $! SlowFail bs "expected bytes"
-      DecodedToken sz (Fits bstr)   -> go_fast_end (k bstr) (BS.unsafeDrop sz bs)
+      DecodedToken sz (Fits bstr)   -> k bstr >>= flip go_fast_end (BS.unsafeDrop sz bs)
       DecodedToken sz (TooLong len) -> return $! SlowConsumeTokenBytes (BS.unsafeDrop sz bs) k len
 
 go_fast_end (ConsumeString k) !bs =
     case tryConsumeString (BS.unsafeHead bs) bs of
       DecodeFailure                 -> return $! SlowFail bs "expected string"
-      DecodedToken sz (Fits str)    -> go_fast_end (k str) (BS.unsafeDrop sz bs)
+      DecodedToken sz (Fits str)    -> k str >>= flip go_fast_end (BS.unsafeDrop sz bs)
       DecodedToken sz (TooLong len) -> return $! SlowConsumeTokenString (BS.unsafeDrop sz bs) k len
 
 go_fast_end (ConsumeBool k) !bs =
     case tryConsumeBool (BS.unsafeHead bs) of
       DecodeFailure     -> return $! SlowFail bs "expected bool"
-      DecodedToken sz b -> go_fast_end (k b) (BS.unsafeDrop sz bs)
+      DecodedToken sz b -> k b >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeSimple k) !bs =
     case tryConsumeSimple (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected simple"
-      DecodedToken sz (W# w#) -> go_fast_end (k w#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (W# w#) -> k w# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeBytesIndef k) !bs =
     case tryConsumeBytesIndef (BS.unsafeHead bs) of
       DecodeFailure     -> return $! SlowFail bs "expected bytes start"
-      DecodedToken sz _ -> go_fast_end k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeStringIndef k) !bs =
     case tryConsumeStringIndef (BS.unsafeHead bs) of
       DecodeFailure     -> return $! SlowFail bs "expected string start"
-      DecodedToken sz _ -> go_fast_end k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeListLenIndef k) !bs =
     case tryConsumeListLenIndef (BS.unsafeHead bs) of
       DecodeFailure     -> return $! SlowFail bs "expected list start"
-      DecodedToken sz _ -> go_fast_end k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeMapLenIndef k) !bs =
     case tryConsumeMapLenIndef (BS.unsafeHead bs) of
       DecodeFailure     -> return $! SlowFail bs "expected map start"
-      DecodedToken sz _ -> go_fast_end k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeNull k) !bs =
     case tryConsumeNull (BS.unsafeHead bs) of
       DecodeFailure     -> return $! SlowFail bs "expected null"
-      DecodedToken sz _ -> go_fast_end k (BS.unsafeDrop sz bs)
+      DecodedToken sz _ -> k >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeListLenOrIndef k) !bs =
     case tryConsumeListLenOrIndef (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected list len or indef"
-      DecodedToken sz (I# n#) -> go_fast_end (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 go_fast_end (ConsumeMapLenOrIndef k) !bs =
     case tryConsumeMapLenOrIndef (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected map len or indef"
-      DecodedToken sz (I# n#) -> go_fast_end (k n#) (BS.unsafeDrop sz bs)
+      DecodedToken sz (I# n#) -> k n# >>= flip go_fast_end (BS.unsafeDrop sz bs)
 
 
 -- The slow path starts off by running the fast path on the current chunk
@@ -677,7 +677,7 @@ go_fast_end (ConsumeMapLenOrIndef k) !bs =
 -- The offset here is the offset after of all data consumed so far,
 -- so not including the current chunk.
 --
-go_slow :: DecodeAction a -> ByteString -> ByteOffset
+go_slow :: DecodeAction s a -> ByteString -> ByteOffset
         -> IncrementalDecoder s (ByteString, ByteOffset, a)
 go_slow da bs !offset = do
   slowpath <- lift $ go_fast da bs
@@ -688,14 +688,14 @@ go_slow da bs !offset = do
 
     SlowConsumeTokenBytes bs' k len -> do
       (bstr, bs'') <- getTokenVarLen len bs' offset'
-      go_slow (k bstr) bs'' (offset' + fromIntegral len)
+      lift (k bstr) >>= \daz -> go_slow daz bs'' (offset' + fromIntegral len)
       where
         !offset' = offset + fromIntegral (BS.length bs - BS.length bs')
 
     SlowConsumeTokenString bs' k len -> do
       (bstr, bs'') <- getTokenVarLen len bs' offset'
       let !str = T.decodeUtf8 bstr  -- TODO FIXME: utf8 validation
-      go_slow (k str) bs'' (offset' + fromIntegral len)
+      lift (k str) >>= \daz -> go_slow daz bs'' (offset' + fromIntegral len)
       where
         !offset' = offset + fromIntegral (BS.length bs - BS.length bs')
 
@@ -727,7 +727,7 @@ go_slow da bs !offset = do
 -- Our goal is to get enough input so that go_fast_end can consume exactly one
 -- token without need for further fixups.
 --
-go_slow_fixup :: DecodeAction a -> ByteString -> ByteOffset
+go_slow_fixup :: DecodeAction s a -> ByteString -> ByteOffset
               -> IncrementalDecoder s (ByteString, ByteOffset, a)
 go_slow_fixup da !bs !offset = do
     let !hdr = BS.head bs
@@ -747,7 +747,7 @@ go_slow_fixup da !bs !offset = do
 
 -- We've now got more input, but we have one token that spanned the old and
 -- new input buffers, so we have to decode that one before carrying on
-go_slow_overlapped :: DecodeAction a -> Int -> ByteString -> ByteString
+go_slow_overlapped :: DecodeAction s a -> Int -> ByteString -> ByteString
                    -> ByteOffset
                    -> IncrementalDecoder s (ByteString, ByteOffset, a)
 go_slow_overlapped da sz bs_cur bs_next !offset =
@@ -797,7 +797,7 @@ go_slow_overlapped da sz bs_cur bs_next !offset =
                           else let !bstr = BS.take len bs'
                                    !bs'' = BS.drop len bs'
                                 in return (bstr, bs'')
-        go_slow (k bstr) bs'' (offset' + fromIntegral len)
+        lift (k bstr) >>= \daz -> go_slow daz bs'' (offset' + fromIntegral len)
 
       SlowConsumeTokenString bs_empty k len ->
         assert (BS.null bs_empty) $ do
@@ -807,7 +807,7 @@ go_slow_overlapped da sz bs_cur bs_next !offset =
                                    !bs'' = BS.drop len bs'
                                 in return (bstr, bs'')
         let !str = T.decodeUtf8 bstr  -- TODO FIXME: utf8 validation
-        go_slow (k str) bs'' (offset' + fromIntegral len)
+        lift (k str) >>= \daz -> go_slow daz bs'' (offset' + fromIntegral len)
 
       SlowFail bs_unconsumed msg ->
         decodeFail (bs_unconsumed <> bs') offset'' msg
@@ -1902,8 +1902,8 @@ data BigIntToken a = BigIntToken Integer
 -- Integer before calling the original continuation.
 
 adjustContBigUIntNeedBody, adjustContBigNIntNeedBody
-  :: (Integer -> DecodeAction a)
-  -> (ByteString -> DecodeAction a)
+  :: (Integer -> ST s (DecodeAction s a))
+  -> (ByteString -> ST s (DecodeAction s a))
 
 adjustContBigUIntNeedBody k = \bs -> k $! uintegerFromBytes bs
 adjustContBigNIntNeedBody k = \bs -> k $! nintegerFromBytes bs
@@ -1918,8 +1918,8 @@ adjustContBigNIntNeedBody k = \bs -> k $! nintegerFromBytes bs
 -- adjust the continuation for that in the same way as above.
 
 adjustContBigUIntNeedHeader, adjustContBigNIntNeedHeader
-  :: (Integer -> DecodeAction a)
-  -> DecodeAction a
+  :: (Integer -> ST s (DecodeAction s a))
+  -> DecodeAction s a
 
 adjustContBigUIntNeedHeader k = ConsumeBytes (\bs -> k $! uintegerFromBytes bs)
 adjustContBigNIntNeedHeader k = ConsumeBytes (\bs -> k $! nintegerFromBytes bs)

--- a/Data/Binary/Serialise/CBOR/Read.hs
+++ b/Data/Binary/Serialise/CBOR/Read.hs
@@ -41,6 +41,7 @@ import           Control.Applicative
 import           GHC.Int
 
 import           Control.Monad (ap)
+import           Control.Monad.ST
 import           Data.Array.IArray
 import           Data.Array.Unboxed
 import qualified Data.Array.Base as A
@@ -67,14 +68,6 @@ import qualified GHC.Integer.GMP.Internals      as Gmp
 import           System.IO.Unsafe               (unsafePerformIO)
 #endif
 
-#if defined(USE_ST)
-import Control.Monad.ST
-#else
-import Control.Monad.Identity (Identity(..))
-type ST s a = Identity a
-runST :: (forall s. ST s a) -> a
-runST = runIdentity
-#endif
 
 --------------------------------------------------------------------------------
 

--- a/Data/Binary/Serialise/CBOR/Term.hs
+++ b/Data/Binary/Serialise/CBOR/Term.hs
@@ -129,7 +129,7 @@ encodeTerm (TDouble   f)  = encodeDouble  f
 -- | Decode some arbitrary CBOR value into a @'Term'@.
 --
 -- @since 0.2.0.0
-decodeTerm :: Decoder Term
+decodeTerm :: Decoder s Term
 decodeTerm = do
     tkty <- peekTokenType
     case tkty of
@@ -206,7 +206,7 @@ decodeTerm = do
 --------------------------------------------------------------------------------
 -- Internal utilities
 
-decodeBytesIndefLen :: [BS.ByteString] -> Decoder Term
+decodeBytesIndefLen :: [BS.ByteString] -> Decoder s Term
 decodeBytesIndefLen acc = do
     stop <- decodeBreakOr
     if stop then return $! TBytesI (LBS.fromChunks (reverse acc))
@@ -214,7 +214,7 @@ decodeBytesIndefLen acc = do
                     decodeBytesIndefLen (bs : acc)
 
 
-decodeStringIndefLen :: [T.Text] -> Decoder Term
+decodeStringIndefLen :: [T.Text] -> Decoder s Term
 decodeStringIndefLen acc = do
     stop <- decodeBreakOr
     if stop then return $! TStringI (LT.fromChunks (reverse acc))
@@ -222,7 +222,7 @@ decodeStringIndefLen acc = do
                     decodeStringIndefLen (str : acc)
 
 
-decodeListN :: Int -> [Term] -> Decoder Term
+decodeListN :: Int -> [Term] -> Decoder s Term
 decodeListN !n acc =
     case n of
       0 -> return $! TList (reverse acc)
@@ -230,7 +230,7 @@ decodeListN !n acc =
               decodeListN (n-1) (t : acc)
 
 
-decodeListIndefLen :: [Term] -> Decoder Term
+decodeListIndefLen :: [Term] -> Decoder s Term
 decodeListIndefLen acc = do
     stop <- decodeBreakOr
     if stop then return $! TListI (reverse acc)
@@ -238,7 +238,7 @@ decodeListIndefLen acc = do
                     decodeListIndefLen (tm : acc)
 
 
-decodeMapN :: Int -> [(Term, Term)] -> Decoder Term
+decodeMapN :: Int -> [(Term, Term)] -> Decoder s Term
 decodeMapN !n acc =
     case n of
       0 -> return $! TMap (reverse acc)
@@ -247,7 +247,7 @@ decodeMapN !n acc =
               decodeMapN (n-1) ((tm, tm') : acc)
 
 
-decodeMapIndefLen :: [(Term, Term)] -> Decoder Term
+decodeMapIndefLen :: [(Term, Term)] -> Decoder s Term
 decodeMapIndefLen acc = do
     stop <- decodeBreakOr
     if stop then return $! TMapI (reverse acc)

--- a/bench/micro/Micro/CBOR.hs
+++ b/bench/micro/Micro/CBOR.hs
@@ -36,15 +36,15 @@ encodeCtr2 n a b = encodeListLen 3 <> encode (n :: Word) <> encode a <> encode b
 {-# INLINE decodeCtrBody0 #-}
 {-# INLINE decodeCtrBody2 #-}
 
-decodeCtrTag :: Decoder (Word, Int)
+decodeCtrTag :: Decoder s (Word, Int)
 decodeCtrTag = (\len tag -> (tag, len)) <$> decodeListLen <*> decodeWord
 
-decodeCtrBody0 :: Int -> a -> Decoder a
+decodeCtrBody0 :: Int -> a -> Decoder s a
 decodeCtrBody0 1 f = pure f
 decodeCtrBody0 x _ = error $ "decodeCtrBody0: impossible tag " ++ show x
 
 decodeCtrBody2
-  :: (Serialise a, Serialise b) => Int -> (a -> b -> c) -> Decoder c
+  :: (Serialise a, Serialise b) => Int -> (a -> b -> c) -> Decoder s c
 decodeCtrBody2 3 f = do x1 <- decode
                         x2 <- decode
                         return (f x1 x2)

--- a/bench/micro/Micro/CBOR.hs
+++ b/bench/micro/Micro/CBOR.hs
@@ -7,13 +7,10 @@ import Micro.Types
 import Data.Binary.Serialise.CBOR.Class
 import Data.Binary.Serialise.CBOR.Encoding
 import Data.Binary.Serialise.CBOR.Decoding hiding (DecodeAction(Done, Fail))
-import Data.Binary.Serialise.CBOR.Read
-import Data.Binary.Serialise.CBOR.Write
+import qualified Data.Binary.Serialise.CBOR as CBOR
 import Data.Monoid
 
 import qualified Data.ByteString.Lazy as BS
-import qualified Data.ByteString.Lazy.Internal as BS
-import qualified Data.ByteString.Builder as BS
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
@@ -21,17 +18,10 @@ import Data.Word
 #endif
 
 serialise :: Tree -> BS.ByteString
-serialise = BS.toLazyByteString . toBuilder . encode
+serialise = CBOR.serialise
 
 deserialise :: BS.ByteString -> Tree
-deserialise = feedAll (deserialiseIncremental decode)
-  where
-    feedAll (Done _ _ x)    _ = x
-    feedAll (Partial k) lbs   = case lbs of
-      BS.Chunk bs lbs' -> feedAll (k (Just bs)) lbs'
-      BS.Empty         -> feedAll (k Nothing) BS.empty
-    feedAll (Fail _ _ exn) _ =
-      error ("Micro.CBOR.feedAll exception: " ++ show exn)
+deserialise = CBOR.deserialise
 
 encodeCtr0 :: Word -> Encoding
 encodeCtr2 :: (Serialise a, Serialise b) => Word -> a -> b -> Encoding

--- a/bench/versus/Macro/CBOR.hs
+++ b/bench/versus/Macro/CBOR.hs
@@ -34,11 +34,12 @@ deserialise = either throw id . deserialiseFromBytes decode
 deserialiseNull :: BS.ByteString -> ()
 deserialiseNull = either throw id . deserialiseFromBytes decodeListNull
   where
+    decodeListNull :: Decoder s ()
     decodeListNull = do decodeListLenIndef; go
 
     go = do stop <- decodeBreakOr
             if stop then return ()
-                    else do !_ <- decode :: Decoder GenericPackageDescription
+                    else do !_ <- decode :: Decoder s GenericPackageDescription
                             go
 
 encodeCtr0 n     = encodeListLen 1 <> encode (n :: Word)

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -53,6 +53,11 @@ flag optimize-gmp
   manual: False
   description: Use optimized code paths for integer-gmp
 
+flag use-st
+  default: False
+  manual: True
+  description: Experimental use of ST monad for decoder
+
 --------------------------------------------------------------------------------
 -- Library
 
@@ -97,6 +102,12 @@ library
     cpp-options:            -DFLAG_OPTIMIZE_GMP
     build-depends:
       integer-gmp
+
+  -- hacking
+  if flag(use-st)
+    cpp-options:            -DUSE_ST
+  else
+    build-depends:          mtl
 
   if flag(newtime15)
     build-depends:

--- a/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor.cabal
@@ -53,11 +53,6 @@ flag optimize-gmp
   manual: False
   description: Use optimized code paths for integer-gmp
 
-flag use-st
-  default: False
-  manual: True
-  description: Experimental use of ST monad for decoder
-
 --------------------------------------------------------------------------------
 -- Library
 
@@ -102,12 +97,6 @@ library
     cpp-options:            -DFLAG_OPTIMIZE_GMP
     build-depends:
       integer-gmp
-
-  -- hacking
-  if flag(use-st)
-    cpp-options:            -DUSE_ST
-  else
-    build-depends:          mtl
 
   if flag(newtime15)
     build-depends:

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-packages:
-  *.cabal
---benchmarks: True
---profiling: True
+packages: ./
+
+tests: True
+benchmarks: True

--- a/tests/Tests/CBOR.hs
+++ b/tests/Tests/CBOR.hs
@@ -28,6 +28,7 @@ import           Tests.Reference (TestCase(..))
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
 #endif
+import           Control.Exception (throw)
 
 
 externalTestCase :: TestCase -> Assertion
@@ -123,10 +124,7 @@ serialise :: Term -> LBS.ByteString
 serialise = toLazyByteString . encodeTerm
 
 deserialise :: LBS.ByteString -> Term
-deserialise encoded =
-    case deserialiseFromBytes decodeTerm encoded of
-      Left msg   -> error $ "deserialise: " ++ msg
-      Right term -> term
+deserialise = either throw id . deserialiseFromBytes decodeTerm
 
 ------------------------------------------------------------------------------
 

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -100,7 +100,7 @@ prop_encodeFloatToDouble x = Right dbl == fromFlatTerm dec ft
   where
     dbl = float2Double x
 
-    dec = decode :: Decoder Double
+    dec = decode :: Decoder s Double
     ft  = toFlatTerm (encode x)
 
 --------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ prop_decodeTag1UTCTimeInteger = testCase "Decode tag 1 UTCTime (Integer)" $
   where
     toks e = TkTag 1 $ TkInteger 1363896240 $ e
     mar21 = UTCTime (fromGregorian 2013 3 21) (timeOfDayToTime (TimeOfDay 20 4 0))
-    dec = decode :: Decoder UTCTime
+    dec = decode :: Decoder s UTCTime
 
 prop_decodeTag1UTCTimeDouble :: TestTree
 prop_decodeTag1UTCTimeDouble = testCase "Decode tag 1 UTCTime (Double)" $
@@ -120,7 +120,7 @@ prop_decodeTag1UTCTimeDouble = testCase "Decode tag 1 UTCTime (Double)" $
   where
     toks e = TkTag 1 $ TkFloat64 1363896240.5 $ e
     mar21 = UTCTime (fromGregorian 2013 3 21) (timeOfDayToTime (TimeOfDay 20 4 0.5))
-    dec = decode :: Decoder UTCTime
+    dec = decode :: Decoder s UTCTime
 
 --------------------------------------------------------------------------------
 -- TestTree API


### PR DESCRIPTION
The big win is we add a `liftST` operation that allows running ST actions in the decoder monad. This allows decoding instances to use things like mutable arrays etc. This is important for instances for vectors and other similar types.