### PR TITLE
Use fromDistinctAscList for Data.{Int}Set decoding

### DIFF
--- a/src/Data/Binary/Serialise/CBOR/Class.hs
+++ b/src/Data/Binary/Serialise/CBOR/Class.hs
@@ -943,12 +943,12 @@ decodeSetSkel fromList = do
 -- | @since 0.2.0.0
 instance (Ord a, Serialise a) => Serialise (Set.Set a) where
   encode = encodeSetSkel Set.size Set.foldr
-  decode = decodeSetSkel Set.fromList
+  decode = decodeSetSkel Set.fromDistinctAscList
 
 -- | @since 0.2.0.0
 instance Serialise IntSet.IntSet where
   encode = encodeSetSkel IntSet.size IntSet.foldr
-  decode = decodeSetSkel IntSet.fromList
+  decode = decodeSetSkel IntSet.fromDistinctAscList
 
 -- | @since 0.2.0.0
 instance (Serialise a, Hashable a, Eq a) => Serialise (HashSet.HashSet a) where

--- a/tests/Tests/Serialise.hs
+++ b/tests/Tests/Serialise.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE DeriveGeneric       #-}
@@ -239,6 +239,9 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T (Map.Map Int String))
       , mkTest (T :: T (Sequence.Seq Int))
       , mkTest (T :: T (Set.Set Int))
+      , mkTest (T :: T (Set.Set Text.Text))
+      , mkTest (T :: T (Set.Set Double))
+      , mkTest (T :: T (Set.Set Rational))
       , mkTest (T :: T IntSet.IntSet)
       , mkTest (T :: T (IntMap.IntMap String))
       , mkTest (T :: T (HashMap.HashMap Int String))


### PR DESCRIPTION
Fixes #113, and adds some more tests for different types contained in a Set.