### PR TITLE
Drop cbor-tool's dep on serialise package

### DIFF
--- a/cbor-tool/cbor-tool.cabal
+++ b/cbor-tool/cbor-tool.cabal
@@ -19,7 +19,7 @@ executable cbor-tool
   main-is:             Main.hs
   other-extensions:    CPP, BangPatterns
   build-depends:
-    base >=4.9 && <4.10,
+    base >=4.7 && <4.10,
     filepath >=1.0 && <1.5,
     aeson >=0.7 && <1.2,
     aeson-pretty >=0.8 && <0.9,
@@ -29,6 +29,5 @@ executable cbor-tool
     text >=1.1 && <1.3,
     vector >=0.10 && <0.13,
 
-    cborg     ==0.1.*,
-    serialise ==0.1.*
+    cborg     ==0.1.*
   default-language:    Haskell2010


### PR DESCRIPTION
This makes sense since the cbor tool is specifically for looking at CBOR format files, so in principle should not depend on the serialise package or Serialise class at all.

Completely untested. Note that there are currently no tests for the CBOR <-> JSON conversions.